### PR TITLE
Implement ChildNodes#item

### DIFF
--- a/src/native-tree.js
+++ b/src/native-tree.js
@@ -51,6 +51,9 @@ export function childNodes(node) {
     nodes.push(n);
     n = nodeWalker.nextSibling();
   }
+  nodes.item = function(index){
+    return nodes[index];
+  };
   return nodes;
 }
 


### PR DESCRIPTION
This adds this childNodes.item function, an alternative way to access a
child by index that some libraries use.