### PR TITLE
Fix `isConnected`; export `ShadyRoot` as `ShadowRoot`.

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -26,6 +26,7 @@ import * as nativeMethods from './native-methods'
 import * as nativeTree from './native-tree'
 import {patchBuiltins} from './patch-builtins'
 import {patchEvents} from './patch-events'
+import {ShadyRoot} from './attach-shadow'
 
 if (utils.settings.inUse) {
 
@@ -50,4 +51,5 @@ if (utils.settings.inUse) {
   // Apply patches to builtins (e.g. Element.prototype) where applicable.
   patchBuiltins();
 
+  window.ShadowRoot = ShadyRoot;
 }

--- a/src/patch-builtins.js
+++ b/src/patch-builtins.js
@@ -55,6 +55,9 @@ let nodeMixin = {
   },
 
   get isConnected() {
+    // Fast path for distributed nodes.
+    if (this.ownerDocument.documentElement.contains(this)) return true;
+
     let node = this;
     while (node && !(node instanceof Document)) {
       node = node.parentNode || (node instanceof ShadyRoot ? node.host : undefined);

--- a/src/patch-builtins.js
+++ b/src/patch-builtins.js
@@ -15,7 +15,7 @@ import * as mutation from './logical-mutation'
 import {ActiveElementAccessor, ShadowRootAccessor, patchAccessors} from './patch-accessors'
 import {getProperty} from './logical-properties'
 import {addEventListener, removeEventListener} from './patch-events'
-import {attachShadow} from './attach-shadow'
+import {attachShadow, ShadyRoot} from './attach-shadow'
 
 function getAssignedSlot(node) {
   mutation.renderRootNode(node);
@@ -55,7 +55,11 @@ let nodeMixin = {
   },
 
   get isConnected() {
-    return document.documentElement.contains(this)
+    let node = this;
+    while (node && !(node instanceof Document)) {
+      node = node.parentNode || (node instanceof ShadyRoot ? node.host : undefined);
+    }
+    return !!(node && node instanceof Document);
   }
 
 };


### PR DESCRIPTION
`isConnected` == "This node's deep root is any Document."

This PR also creates a ShadyRoot constructor (which isn't user constructible) and exposes it as `ShadowRoot`.

FWIW, I don't really know what situations the comment about DocumentFragments not being extensible in older browsers applies to. I *think* this should work since it still doesn't actually extend DocumentFragment.