### PR TITLE
don't return null for classNames accessor

### DIFF
--- a/src/patch-accessors.js
+++ b/src/patch-accessors.js
@@ -104,7 +104,8 @@ let OutsideAccessors = {
      * @this {HTMLElement}
      */
     get() {
-      return this.getAttribute('class');
+      let className =  this.getAttribute('class');
+      return this.getAttribute('class') ? className : '';
     },
     /**
      * @this {HTMLElement}

--- a/src/patch-accessors.js
+++ b/src/patch-accessors.js
@@ -104,8 +104,7 @@ let OutsideAccessors = {
      * @this {HTMLElement}
      */
     get() {
-      let className =  this.getAttribute('class');
-      return className ? className : '';
+      return this.getAttribute('class') || '';
     },
     /**
      * @this {HTMLElement}

--- a/src/patch-accessors.js
+++ b/src/patch-accessors.js
@@ -105,7 +105,7 @@ let OutsideAccessors = {
      */
     get() {
       let className =  this.getAttribute('class');
-      return this.getAttribute('class') ? className : '';
+      return className ? className : '';
     },
     /**
      * @this {HTMLElement}


### PR DESCRIPTION
I was using [ this piano element with dat-gui](https://micahscopes.github.io/all-around-keyboard/examples/datgui.html).  dat-gui is a very popular UI controller widget you've probably seen in a lot of THREE.js examples.

dat-gui didn't like shadydom's className patch, which sometimes returns null in firefox.

I checked out the behavior of className in chrome, and found that even if you set it to null, it will always return an empty string.  I think it's important for this polyfill to be consistent with that behavior.