### PR TITLE
Fix subheadings not rendered properly in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ShadyDOM provides a shim for ShadowDOM V1. It is less correct but less intrusive
 and faster than the ShadowDOM Polyfill.
 
-##Usage
+## Usage
 
 Usage of the shim is transparent when `attachShadow` is unavailable. Elements are
 patched as needed to report ShadowDOM correct dom information. Only dom tree
@@ -13,7 +13,7 @@ accessors and mutation api is maintained. Some dom api
 To force ShadyDOM to be used even when native ShadowDOM is available, set
 the `ShadyDOM = {force: true}` in a script prior to loading the polyfill.
 
-##Example
+## Example
 
 ```html
 <div id="host"></div>
@@ -24,7 +24,7 @@ the `ShadyDOM = {force: true}` in a script prior to loading the polyfill.
 
 ```
 
-##Limitations
+## Limitations
 
 ShadyDOM distribution is asynchronous for performance reasons. This means that
 the composed dom will be available 1 microtask after the dom mutation occurs.


### PR DESCRIPTION
Subheadings currently do not have a space after the pound symbol which causes them to be rendered as normal text