### PR TITLE
Make tests more easily runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ the `ShadyDOM = {force: true}` in a script prior to loading the polyfill.
 
 ```
 
+## Building and running tests
+
+To build the library:
+
+```
+npm install
+gulp
+```
+
+To run tests, first run `bower install` then open `tests/runner.html` in a
+supported browser.
+
 ## Limitations
 
 ShadyDOM distribution is asynchronous for performance reasons. This means that

--- a/tests/active-element.html
+++ b/tests/active-element.html
@@ -11,8 +11,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../../template/template.js"></script>
+  <script src="../bower_components/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../bower_components/template/template.js"></script>
   <script>
     ShadyDOM = {force: true};
     if (window.customElements) {
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </script>
   <script src="../shadydom.min.js"></script>
-  <script src="../../custom-elements/custom-elements.min.js"></script>
+  <script src="../bower_components/custom-elements/custom-elements.min.js"></script>
   <script>
     // Ensure customElements are updated when document is ready.
     if (customElements.polyfillWrapFlushCallback) {
@@ -30,7 +30,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </script>
 
-  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
 </head>
 <body>
 

--- a/tests/event-path.html
+++ b/tests/event-path.html
@@ -11,13 +11,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../../template/template.js"></script>
+  <script src="../bower_components/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../bower_components/template/template.js"></script>
   <script>
     ShadyDOM = {force: true};
   </script>
   <script src="../shadydom.min.js"></script>
-  <script src="../../custom-elements/custom-elements.min.js"></script>
+  <script src="../bower_components/custom-elements/custom-elements.min.js"></script>
   <script>
     // Ensure customElements are updated when document is ready.
     if (customElements.polyfillWrapFlushCallback) {
@@ -31,7 +31,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </script>
 
-  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
 </head>
 <body>
 

--- a/tests/filter-mutations.html
+++ b/tests/filter-mutations.html
@@ -11,13 +11,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../bower_components/webcomponents-platform/webcomponents-platform.js"></script>
   <script>
     ShadyDOM = {force: true};
   </script>
   <script src="../shadydom.min.js"></script>
 
-  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
 </head>
 <body>
 

--- a/tests/observeChildren.html
+++ b/tests/observeChildren.html
@@ -11,13 +11,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../bower_components/webcomponents-platform/webcomponents-platform.js"></script>
   <script>
     ShadyDOM = {force: true};
   </script>
   <script src="../shadydom.min.js"></script>
 
-  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
 </head>
 <body>
 

--- a/tests/runner.html
+++ b/tests/runner.html
@@ -11,7 +11,7 @@
 <title>ShadyDOM Tests</title>
 <meta charset="utf-8">
 
-<script src="../../web-component-tester/browser.js"></script>
+<script src="../bower_components/web-component-tester/browser.js"></script>
 
 <script>
   var suites = [

--- a/tests/shady-content.html
+++ b/tests/shady-content.html
@@ -12,8 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <head>
   <meta charset="utf-8">
 
-  <script src="../../webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../../template/template.js"></script>
+  <script src="../bower_components/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../bower_components/template/template.js"></script>
   <script>
     ShadyDOM = {force: true};
     if (window.customElements) {
@@ -21,7 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </script>
   <script src="../shadydom.min.js"></script>
-  <script src="../../custom-elements/custom-elements.min.js"></script>
+  <script src="../bower_components/custom-elements/custom-elements.min.js"></script>
   <script>
     // Ensure customElements are updated when document is ready.
     if (customElements.polyfillWrapFlushCallback) {
@@ -35,9 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </script>
 
-  <!-- <script src="../../webcomponentsjs/webcomponents-lite.js"></script> -->
-
-  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
 </head>
 <body>
 

--- a/tests/shady-dynamic.html
+++ b/tests/shady-dynamic.html
@@ -11,8 +11,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../webcomponents-platform/webcomponents-platform.js"></script>
-  <script src="../../template/template.js"></script>
+  <script src="../bower_components/webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../bower_components/template/template.js"></script>
   <script>
     ShadyDOM = {force: true};
     if (window.customElements) {
@@ -20,7 +20,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </script>
   <script src="../shadydom.min.js"></script>
-  <script src="../../custom-elements/custom-elements.min.js"></script>
+  <script src="../bower_components/custom-elements/custom-elements.min.js"></script>
   <script>
     // Ensure customElements are updated when document is ready.
     if (customElements.polyfillWrapFlushCallback) {
@@ -34,7 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
   </script>
 
-  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
 </head>
 <body>
 

--- a/tests/shady.html
+++ b/tests/shady.html
@@ -11,13 +11,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../bower_components/webcomponents-platform/webcomponents-platform.js"></script>
   <script>
     ShadyDOM = {force: true};
   </script>
   <script src="../shadydom.min.js"></script>
 
-  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
 </head>
 <body>
 <script>

--- a/tests/slotchange.html
+++ b/tests/slotchange.html
@@ -11,13 +11,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../webcomponents-platform/webcomponents-platform.js"></script>
+  <script src="../bower_components/webcomponents-platform/webcomponents-platform.js"></script>
   <script>
     ShadyDOM = {force: true};
   </script>
   <script src="../shadydom.min.js"></script>
 
-  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
 </head>
 <body>
 

--- a/tests/smoke/click.html
+++ b/tests/smoke/click.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html>
   <head>
-    <script src="../../../webcomponents-platform/webcomponents-platform.js"></script>
-    <script src="../../../template/template.js"></script>
+    <script src="../../bower_components/webcomponents-platform/webcomponents-platform.js"></script>
+    <script src="../../bower_components/template/template.js"></script>
     <script>
       ShadyDOM = {force: true};
       if (window.customElements) {
@@ -10,8 +10,8 @@
       }
     </script>
     <script src="../../shadydom.min.js"></script>
-    <script src="../../../custom-elements/custom-elements.min.js"></script>
-    <script src="../../../shadycss/scoping-shim.min.js"></script>
+    <script src="../../bower_components/custom-elements/custom-elements.min.js"></script>
+    <script src="../../bower_components/shadycss/scoping-shim.min.js"></script>
   </head>
   <body>
     <script>

--- a/tests/smoke/smoke.html
+++ b/tests/smoke/smoke.html
@@ -14,8 +14,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     ShadyDOM = {force: true};
   </script>
-  <script src="../../../webcomponentsjs/src/WebComponents/dom.js"></script>
-  <script src="../../../webcomponentsjs/src/WebComponents/lang.js"></script>
   <script src="../../shadydom.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Fixes #80. Tests should be runnable after invoking `bower install`.