### PR TITLE
Prevent renaming of properties added to Window and Node

### DIFF
--- a/externs/shadydom.js
+++ b/externs/shadydom.js
@@ -1,14 +1,30 @@
 /**
- * @fileoverview Externs to upstream to closure compiler
+ * @fileoverview Externs for closure compiler
  * @externs
  */
 
 /**
+ * Upstream to closure-compiler
  * @type {string}
  */
 Element.prototype.slot;
 
 /**
+ * Upstream to closure-compiler
  * @type {Object}
  */
 Node.prototype.__shady;
+
+/**
+ * Block renaming of properties added to Window to
+ * prevent conflicts with other closure-compiler code.
+ * @type {Object}
+ */
+Window.prototype.__handlers;
+
+/**
+ * Block renaming of properties added to Node to
+ * prevent conflicts with other closure-compiler code.
+ * @type {Object}
+ */
+Node.prototype.__handlers;


### PR DESCRIPTION
Fixes #153 

The `__handlers` object added to `Window` and `Node` in https://github.com/webcomponents/shadydom/blob/master/src/patch-events.js is renamed by closure-compiler. The renamed Window object property in particular becomes a global variable which can conflict with other code.

Adding this property to the externs prevents renaming.