### PR TITLE
Don't swallow window events

### DIFF
--- a/src/patch-events.js
+++ b/src/patch-events.js
@@ -352,7 +352,7 @@ export function addEventListener(type, fnOrObj, optionsOrCapture) {
         return;
       }
       // prevent non-bubbling events from triggering bubbling handlers on shadowroot, but only if not in capture phase
-      if (e.eventPhase !== Event.CAPTURING_PHASE && !e.bubbles && e.target !== target) {
+      if (e.eventPhase !== Event.CAPTURING_PHASE && !e.bubbles && e.target !== target && !(target instanceof Window)) {
         return;
       }
       let ret = (typeof fnOrObj === 'object' && fnOrObj.handleEvent) ?


### PR DESCRIPTION
The current implementation seems to swallow, ignore the 'load' event at least when fired from window. An issue has been created [here](https://github.com/webcomponents/webcomponentsjs/issues/836).
Below is my attempt to solve it
<hr>

_Added by @azakus_ 
Fixes webcomponents/webcomponentsjs#836