### PR TITLE
fix the issue with non-inspectable shadydom.min.js in dev tools

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,7 @@ let rollup = require('gulp-rollup');
 const size = require('gulp-size');
 
 gulp.task('default', () => {
-  return gulp.src('./src/*.js')
+  return gulp.src('./src/*.js', {base: '.'})
     .pipe(sourcemaps.init())
     .pipe(closureCompiler({
       new_type_inf: true,


### PR DESCRIPTION
(_this is a similar issue to https://github.com/webcomponents/webcomponentsjs/pull/858_)

Due to a misconfiguration of the gulp build pipeline, the source map for the minified polyfill file `shadydom.min.js` is missing the contents of the original source files. This causes the polyfill to be non-inspectable in the browser developer tools (compare the before and after screenshots below).

Before:
<img width="913" alt="before-sources-are-not-inspectable" src="https://user-images.githubusercontent.com/22416150/31854547-ee60723c-b6a3-11e7-8395-6347f227ef70.png">

After:
<img width="918" alt="after-sources-are-inspectable" src="https://user-images.githubusercontent.com/22416150/31854551-f3dfc578-b6a3-11e7-87aa-72e377bcca1d.png">