### PR TITLE
Add build command to remove requirement of global gulp command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ For building and testing, first run
 ```
 npm install
 bower install
+npm run build
 ```
-
-To build, make sure gulp is installed and `gulp`.
 
 To test, run `npm test`
 
@@ -45,4 +44,3 @@ For testing, `ShadyDOM.flush` may be called to force syncronous composition.
 
 ShadowDOM compatible styling is *not* provided with the ShadyDOM shim. To
 shim ShadowDOM styling, use the [shadycss](https://github.com/webcomponents/shadycss) shim.
-

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "url": "https://github.com/webcomponents/shadydom/issues"
   },
   "scripts": {
+    "build": "gulp",
     "test": "wct"
   },
   "homepage": "https://webcomponents.org/polyfills",


### PR DESCRIPTION
This removes the need of having `gulp` globally installed. Developers can now simply run `npm run build` which takes the correct (locally installed) version of `gulp`.