### PR TITLE
Fix timing issue if modifying slot name before rendering

### DIFF
--- a/src/attach-shadow.js
+++ b/src/attach-shadow.js
@@ -485,6 +485,8 @@ class ShadyRoot {
     if (!this._slotList) {
       return;
     }
+    // make sure slotMap is initialized with this slot
+    this._validateSlots();
     const oldName = slot.__slotName;
     const name = this._nameForSlot(slot);
     if (name === oldName) {

--- a/tests/slot-scenarios.html
+++ b/tests/slot-scenarios.html
@@ -188,7 +188,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             window.ShadyDOM.flush();
           }
         });
-      })
+      });
+
+      test('slots can be modified before rendering', function() {
+        const host = document.createElement('div');
+        const child = document.createElement('span');
+        child.textContent = 'Hello!';
+        child.setAttribute('slot', 'foo');
+        host.appendChild(child);
+        host.attachShadow({mode: 'open'});
+        const slot = document.createElement('slot');
+        host.shadowRoot.appendChild(slot);
+        assert.doesNotThrow(() => {
+          slot.setAttribute('name', 'foo');
+        });
+        window.ShadyDOM.flush();
+        assert.equal(child.assignedSlot, slot, 'child should be assigned to slot');
+      });
     })
   </script>
 </body>


### PR DESCRIPTION
slotMap has not been set up yet, so name changes will hit an `undefined`
trying to affect a slot name change

Fixes #264


<!-- Instructions: https://github.com/webcomponents/shadydom/blob/master/CONTRIBUTING.md -->
<!-- Example: Fixes #1234 -->