### PR TITLE
Replace broken 'gulp debug' with 'npm run debug'

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,9 +16,7 @@
 let gulp = require('gulp');
 let compilerPackage = require('google-closure-compiler');
 let sourcemaps = require('gulp-sourcemaps');
-let rename = require('gulp-rename');
 let closureCompiler = compilerPackage.gulp();
-let rollup = require('gulp-rollup');
 const size = require('gulp-size');
 
 gulp.task('default', () => {
@@ -39,15 +37,3 @@ gulp.task('default', () => {
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('./'))
 });
-
-gulp.task('debug', () => {
-  return gulp.src('src/*.js')
-  .pipe(rollup({
-    entry: 'src/shadydom.js',
-    format: 'iife',
-    moduleName: 'shadydom'
-  }))
-  .pipe(rename('shadydom.min.js'))
-  .pipe(size({showFiles: true, showTotal: false, gzip: true}))
-  .pipe(gulp.dest('./'))
-})

--- a/package-lock.json
+++ b/package-lock.json
@@ -3079,15 +3079,9 @@
       }
     },
     "compression": {
-<<<<<<< HEAD
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
       "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
-=======
-      "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
-      "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
->>>>>>> Replace broken 'gulp debug' with 'npm run debug'
       "dev": true,
       "requires": {
         "accepts": "1.3.5",
@@ -5621,37 +5615,6 @@
         "minimatch": "3.0.4"
       }
     },
-<<<<<<< HEAD
-    "gulp-rename": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.3.0.tgz",
-      "integrity": "sha512-nEuZB7/9i0IZ8AXORTizl2QLP9tcC9uWc/s329zElBLJw1CfOhmMXBxwVlCRKjDyrWuhVP0uBKl61KeQ32TiCg==",
-      "dev": true
-    },
-    "gulp-rollup": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/gulp-rollup/-/gulp-rollup-2.16.2.tgz",
-      "integrity": "sha512-Gs9NYcUl0xXod7qenC1Lm49a/PGllAa5ONyCXu29lXfkP1oJnJzSdPBjopm9RlOVhefadbHlfy9AijovFrqABA==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "0.1.2",
-        "plugin-error": "1.0.1",
-        "readable-stream": "2.3.6",
-        "rollup": "0.54.1",
-        "rollup-plugin-hypothetical": "2.1.0",
-        "vinyl": "2.1.0"
-      },
-      "dependencies": {
-        "buffer-from": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
-          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
-          "dev": true
-        }
-      }
-    },
-=======
->>>>>>> Replace broken 'gulp debug' with 'npm run debug'
     "gulp-size": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-size/-/gulp-size-3.0.0.tgz",
@@ -8122,7 +8085,6 @@
         "xmldom": "0.1.27"
       }
     },
-<<<<<<< HEAD
     "plugin-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -8135,8 +8097,6 @@
         "extend-shallow": "3.0.2"
       }
     },
-=======
->>>>>>> Replace broken 'gulp debug' with 'npm run debug'
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3079,9 +3079,15 @@
       }
     },
     "compression": {
+<<<<<<< HEAD
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
       "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+=======
+      "version": "1.7.2",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
+>>>>>>> Replace broken 'gulp debug' with 'npm run debug'
       "dev": true,
       "requires": {
         "accepts": "1.3.5",
@@ -3291,7 +3297,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -4774,8 +4780,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "balanced-match": {
@@ -4788,7 +4794,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -4852,7 +4858,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "fs.realpath": {
@@ -4867,14 +4873,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "glob": {
@@ -4883,12 +4889,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "has-unicode": {
@@ -4903,7 +4909,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": "^2.1.0"
           }
         },
         "ignore-walk": {
@@ -4912,7 +4918,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "inflight": {
@@ -4921,8 +4927,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -4941,7 +4947,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
@@ -4955,7 +4961,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -4968,8 +4974,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
@@ -4978,7 +4984,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "2.2.4"
+            "minipass": "^2.2.1"
           }
         },
         "mkdirp": {
@@ -5001,9 +5007,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -5012,16 +5018,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.0",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
@@ -5030,8 +5036,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npm-bundled": {
@@ -5046,8 +5052,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npmlog": {
@@ -5056,10 +5062,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -5078,7 +5084,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -5099,8 +5105,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -5121,10 +5127,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.5.1",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5141,13 +5147,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
@@ -5156,7 +5162,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -5199,9 +5205,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -5210,7 +5216,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -5218,7 +5224,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -5233,13 +5239,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
+            "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.1",
+            "yallist": "^3.0.2"
           }
         },
         "util-deprecate": {
@@ -5254,7 +5260,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -5615,6 +5621,7 @@
         "minimatch": "3.0.4"
       }
     },
+<<<<<<< HEAD
     "gulp-rename": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.3.0.tgz",
@@ -5643,6 +5650,8 @@
         }
       }
     },
+=======
+>>>>>>> Replace broken 'gulp debug' with 'npm run debug'
     "gulp-size": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/gulp-size/-/gulp-size-3.0.0.tgz",
@@ -8113,6 +8122,7 @@
         "xmldom": "0.1.27"
       }
     },
+<<<<<<< HEAD
     "plugin-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
@@ -8125,6 +8135,8 @@
         "extend-shallow": "3.0.2"
       }
     },
+=======
+>>>>>>> Replace broken 'gulp debug' with 'npm run debug'
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -9289,16 +9301,14 @@
       }
     },
     "rollup": {
-      "version": "0.54.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.54.1.tgz",
-      "integrity": "sha512-ebUUgUQ7K/sLn67CtO8Jj8H3RgKAoVWrpiJA7enOkwZPZzTCl8GC8CZ00g5jowjX80KgBmzs4Z1MV6cgglT86A==",
-      "dev": true
-    },
-    "rollup-plugin-hypothetical": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-hypothetical/-/rollup-plugin-hypothetical-2.1.0.tgz",
-      "integrity": "sha512-MlxPQTkMtiRUtyhIJ7FpBvTzWtar8eFBA+V7/J6Deg9fSgIIHwL6bJKK1Wl1uWSWtOrWhOmtsMwb9F6aagP/Pg==",
-      "dev": true
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.62.0.tgz",
+      "integrity": "sha512-mZS0aIGfYzuJySJD78znu9/hCJsNfBzg4lDuZGMj0hFVcYHt2evNRHv8aqiu9/w6z6Qn8AQoVl4iyEjDmisGeA==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "*"
+      }
     },
     "run-async": {
       "version": "2.3.0",
@@ -9422,11 +9432,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "nice-try": "1.0.4",
-            "path-key": "2.0.1",
-            "semver": "5.5.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "minimist": {
@@ -11189,7 +11199,7 @@
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.8.0"
           }
         },
         "q": {

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "scripts": {
     "build": "gulp",
     "test": "npm run lint && npm run build && wct",
+    "debug": "rollup -c",
     "lint": "eslint src",
     "regen-package-lock": "rm -rf node_modules package-lock.json; npm install",
-    "prepack": "npm run build",
-    "debug": "gulp debug"
+    "prepack": "npm run build"
   },
   "files": [
     "shadydom.min.js*",
@@ -50,11 +50,10 @@
     "eslint-plugin-html": "^4.0.5",
     "google-closure-compiler": "^20180506.0.0",
     "gulp": "^4.0.0",
-    "gulp-rename": "^1.2.3",
-    "gulp-rollup": "^2.16.2",
     "gulp-size": "^3.0.0",
     "gulp-sourcemaps": "^2.6.4",
     "promise-polyfill": "^8.0.0",
+    "rollup": "^0.62.0",
     "wct-browser-legacy": "^1.0.1",
     "web-component-tester": "^6.7.1"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,4 @@
-const config = {
+export default {
   input: 'src/shadydom.js',
-  output: { file: 'shadydom.min.js', format: 'iife', name: 'shadydom', sourcemap: true }
+  output: { file: 'shadydom.min.js', format: 'iife', sourcemap: true }
 };
-
-export default config;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,6 @@
+const config = {
+  input: 'src/shadydom.js',
+  output: { file: 'shadydom.min.js', format: 'iife', name: 'shadydom', sourcemap: true }
+};
+
+export default config;


### PR DESCRIPTION
The `gulp debug` build command was broken and did not produce any output. I replaced it with a functionally identical `npm run debug` command that invokes Rollup directly to produce the same output.
