### PR TITLE
Skip shadydom composed getter test for IE and Edge

### DIFF
--- a/tests/event-path.html
+++ b/tests/event-path.html
@@ -479,6 +479,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('focusin and focusout events patched to be always composed', function() {
+      // this test only makes sense for browsers having native "composed" getter,
+      // with the others (IE and Edge) the case is not reproducible, so skip.
+      if (Object.getOwnPropertyDescriptor(Event.prototype, 'composed') === undefined) {
+        this.skip();
+      }
       const theDiv = document.createElement('div');
       theDiv.attachShadow({mode: 'open'});
 


### PR DESCRIPTION
Fixes the test regression in #276 by skipping for browsers there the corresponding [code branch](https://github.com/webcomponents/shadydom/blob/b2b87ec1373d7893ed876bcdf89a77ad35b096d7/src/patch-events.js#L141) is unreachable due to lack of the native composed getter (which is being actually tested).

@TimvdLippe I think this should be better than reverting the fix, as long as it has been already tagged in 1.2.0 release done by @azakus, and in those browsers different [code branch](https://github.com/webcomponents/shadydom/blob/b2b87ec1373d7893ed876bcdf89a77ad35b096d7/src/patch-events.js#L144) works.