### PR TITLE
Prevent Node.prototype.__shady from being renamed.

### DIFF
--- a/externs/shadydom.js
+++ b/externs/shadydom.js
@@ -22,3 +22,6 @@ Window.prototype.__handlers;
  * @type {Object}
  */
 Node.prototype.__handlers;
+
+/** @type {Object} */
+Node.prototype.__shady;


### PR DESCRIPTION
The compiler can otherwise rename this to the same name that some other property of Node.prototype has been renamed to in another compiled program.

Same issue as https://github.com/webcomponents/shadycss/pull/217