### PR TITLE
test for issue with dispatching mechanism between host and shadowRoot

### DIFF
--- a/tests/shady-content.html
+++ b/tests/shady-content.html
@@ -1360,6 +1360,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.deepEqual(getComposedChildNodes(inner), [t]);
     });
 
+    test('dispatch order between shadow and host', function() {
+      // render an element with a shadowRoot
+      var x = document.createElement('x-simple');
+      var b = document.createElement('button');
+      document.body.appendChild(x);
+      ShadyDOM.flush();
+      x.shadowRoot.appendChild(b);
+      ShadyDOM.flush();
+      var order = [];
+      b.addEventListener('click', function () { order.push('button'); });
+      // adding listener to the host before the shadow should have no effect on the shadow
+      x.addEventListener('click', function (e) {
+        order.push('host');
+        e.stopImmediatePropagation(); // intentionally stopping the propagation on host
+      });
+      x.shadowRoot.addEventListener('click', function () { order.push('button'); });
+      b.click();
+      assert.deepEqual(order, ['button', 'shadow', 'host']);
+    });
+
   });
 
   function getComposedChildNodes(node) {


### PR DESCRIPTION
Events should dispatch first on the shadowRoot, then on the host. The current implementation is first come first serve, which means adding a listener from outside, right after construction could potentially prevent internal behavior to be executed if that behavior depends on listeners added to the shadowRoot during connectedCallback, or any other important moment.

This is probably a very minor issue, but certainly something to highlight in the docs as a compromise at least.