### PR TITLE
Fix #289 - Use bubbling phase for 'on' event listeners

### DIFF
--- a/src/patch-builtins.js
+++ b/src/patch-builtins.js
@@ -258,7 +258,7 @@ for (const property of Object.getOwnPropertyNames(Document.prototype)) {
         const shadyData = ensureShadyDataForNode(this);
         const eventName = property.substring(2);
         shadyData.__onCallbackListeners[property] && this.removeEventListener(eventName, shadyData.__onCallbackListeners[property]);
-        this.addEventListener(eventName, fn, {});
+        this.addEventListener(eventName, fn);
         shadyData.__onCallbackListeners[property] = fn;
       },
       /** @this {HTMLElement} */

--- a/tests/event-path.html
+++ b/tests/event-path.html
@@ -678,6 +678,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       el.parentNode.removeChild(el);
     });
 
+    test('should use bubbling phase for event listeners added via properties', function () {
+      const parent = document.createElement('div');
+      parent.id = "parent";
+      document.body.appendChild(parent);
+      const child = document.createElement('div');
+      child.id = "child";
+      parent.appendChild(child);
+
+      const parentMouseDownSpy = sinon.spy();
+      const childMouseDownSpy = sinon.spy();
+
+      parent.onmousedown = parentMouseDownSpy;
+      child.onmousedown = childMouseDownSpy;
+
+      child.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
+
+      assert.isTrue(childMouseDownSpy.calledBefore(parentMouseDownSpy), 'Event handler on child should be called first');
+    });
+
     test('.focus() and .blur() work as expected', function() {
       // NOTE: IE 11 fails to work for some reason in Saucelabs when running with WCT
       // Passes when running locally with WCT on the same Saucelabs VMs :/


### PR DESCRIPTION
Do not use empty options object when adding event listener
to patch builtins as it is evaluated as a truthy value thus
allowing the capture flag in browsers without the support of
such an object like IE 11.

Fixes #289
