### PR TITLE
fixes #300: empty id should return null, not the root HTML element

### DIFF
--- a/src/patches/DocumentOrFragment.js
+++ b/src/patches/DocumentOrFragment.js
@@ -17,6 +17,9 @@ export const DocumentOrFragmentPatches = utils.getOwnPropertyDescriptors({
    * @param {string} id
    */
   getElementById(id) {
+    if (id === '') {
+      return null;
+    }
     let result = query(this, function(n) {
       return n.id == id;
     }, function(n) {

--- a/tests/shady.html
+++ b/tests/shady.html
@@ -694,6 +694,15 @@ suite('Patch of innerHTML setter', function() {
   });
 });
 
+suite('Patch of getElementById', function() {
+  [undefined, null, '', 'unknown-elem'].forEach(function(id) {
+    test.only(`should return null for unknown id: "${id}"`, function() {
+      const elem = document.getElementById(id);
+      assert.isNull(elem);
+    });
+  });
+})
+
 function getEffectiveChildNodes(node) {
   var list = [];
   var c$ = ShadyDOM.wrap(node).childNodes;


### PR DESCRIPTION
This fixes #300, which had `document.getElementById('')` (empty string) returning the root `<html>` element instead of `null` like the native one.

I was a little unsure about where the test should live, so happy to move it if it's happier elsewhere. 
