### PR TITLE
Fixes innerHTML and textContent when using custom elements polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -760,19 +760,19 @@
     },
     "@types/clean-css": {
       "version": "3.4.30",
-      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-3.4.30.tgz",
+      "resolved": "http://registry.npmjs.org/@types/clean-css/-/clean-css-3.4.30.tgz",
       "integrity": "sha1-AFLBNvUkgAJCjjY4s33ko5gYZB0=",
       "dev": true
     },
     "@types/clone": {
       "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
+      "resolved": "http://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
       "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
       "dev": true
     },
     "@types/compression": {
       "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
+      "resolved": "http://registry.npmjs.org/@types/compression/-/compression-0.0.33.tgz",
       "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
       "dev": true,
       "requires": {
@@ -796,13 +796,13 @@
     },
     "@types/cssbeautify": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8=",
       "dev": true
     },
     "@types/doctrine": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
       "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0=",
       "dev": true
     },
@@ -820,7 +820,7 @@
     },
     "@types/events": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
       "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
       "dev": true
     },
@@ -886,7 +886,7 @@
     },
     "@types/html-minifier": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.2.tgz",
       "integrity": "sha512-yikK28/KlVyf8g9i/k+TDFlteLuZ6QQTUdVqvKtzEB+8DSLCTjxfh6IK45KnW4rYFI3Y8T4LWpYJMTmfJleWaQ==",
       "dev": true,
       "requires": {
@@ -897,7 +897,7 @@
     },
     "@types/is-windows": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/@types/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
       "dev": true
     },
@@ -922,7 +922,7 @@
     },
     "@types/mz": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
+      "resolved": "http://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
       "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
       "dev": true,
       "requires": {
@@ -938,7 +938,7 @@
     },
     "@types/opn": {
       "version": "3.0.28",
-      "resolved": "https://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
+      "resolved": "http://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "dev": true,
       "requires": {
@@ -947,7 +947,7 @@
     },
     "@types/parse5": {
       "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
+      "resolved": "http://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
@@ -956,7 +956,7 @@
     },
     "@types/path-is-inside": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
       "integrity": "sha512-hfnXRGugz+McgX2jxyy5qz9sB21LRzlGn24zlwN2KEgoPtEvjzNRrLtUkOOebPDPZl3Rq7ywKxYvylVcEZDnEw==",
       "dev": true
     },
@@ -974,7 +974,7 @@
     },
     "@types/relateurl": {
       "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
+      "resolved": "http://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
       "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y=",
       "dev": true
     },
@@ -1061,7 +1061,7 @@
     },
     "@types/whatwg-url": {
       "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
       "integrity": "sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==",
       "dev": true,
       "requires": {
@@ -1138,7 +1138,7 @@
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
@@ -1147,7 +1147,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -1217,7 +1217,7 @@
     },
     "ansi-colors": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
       "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
       "dev": true,
       "requires": {
@@ -1235,7 +1235,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -1431,7 +1431,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -1536,7 +1536,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -1618,7 +1618,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1631,7 +1631,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -1658,7 +1658,7 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         }
@@ -1678,7 +1678,7 @@
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
       "dev": true
     },
@@ -1818,25 +1818,25 @@
     },
     "babel-plugin-transform-member-expression-literals": {
       "version": "6.10.0-alpha.f95869d4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.10.0-alpha.f95869d4.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.10.0-alpha.f95869d4.tgz",
       "integrity": "sha1-Jy69Ki1DQbhsJNzYQ3SuWqNwKHQ=",
       "dev": true
     },
     "babel-plugin-transform-merge-sibling-variables": {
       "version": "6.10.0-alpha.f95869d4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.10.0-alpha.f95869d4.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.10.0-alpha.f95869d4.tgz",
       "integrity": "sha1-SKMw0oKT4xjQcXXCYMdIWec5i0M=",
       "dev": true
     },
     "babel-plugin-transform-minify-booleans": {
       "version": "6.10.0-alpha.f95869d4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.10.0-alpha.f95869d4.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.10.0-alpha.f95869d4.tgz",
       "integrity": "sha1-He72nCITUDipHeH10T11njRkxDw=",
       "dev": true
     },
     "babel-plugin-transform-property-literals": {
       "version": "6.10.0-alpha.f95869d4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.10.0-alpha.f95869d4.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.10.0-alpha.f95869d4.tgz",
       "integrity": "sha1-NxJ6qgQSXD0Iv5XNtajx0uRMpFM=",
       "dev": true,
       "requires": {
@@ -1851,13 +1851,13 @@
     },
     "babel-plugin-transform-remove-console": {
       "version": "6.10.0-alpha.f95869d4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.10.0-alpha.f95869d4.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.10.0-alpha.f95869d4.tgz",
       "integrity": "sha1-xXF6+fdpGLKCHPrvRNgkXU6pQiw=",
       "dev": true
     },
     "babel-plugin-transform-remove-debugger": {
       "version": "6.10.0-alpha.f95869d4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.10.0-alpha.f95869d4.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.10.0-alpha.f95869d4.tgz",
       "integrity": "sha1-H8NcKcfAh4zzDlWKczZRkG6IjkQ=",
       "dev": true
     },
@@ -1872,19 +1872,19 @@
     },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.10.0-alpha.f95869d4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.10.0-alpha.f95869d4.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.10.0-alpha.f95869d4.tgz",
       "integrity": "sha1-9UmabcPtaGvaUzY4ZrZ92ndMW+0=",
       "dev": true
     },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.10.0-alpha.f95869d4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.10.0-alpha.f95869d4.tgz",
       "integrity": "sha1-F1oaMJDmFkA/jIGc3Ooa7LZlI7I=",
       "dev": true
     },
     "babel-preset-minify": {
       "version": "0.4.0-alpha.caaefb4c",
-      "resolved": "https://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.0-alpha.caaefb4c.tgz",
+      "resolved": "http://registry.npmjs.org/babel-preset-minify/-/babel-preset-minify-0.4.0-alpha.caaefb4c.tgz",
       "integrity": "sha1-pQUsWVXdl9JGmbKB/amjAuqMGHE=",
       "dev": true,
       "requires": {
@@ -2123,7 +2123,7 @@
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
       "requires": {
@@ -2356,7 +2356,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -2368,7 +2368,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -2414,7 +2414,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -2436,7 +2436,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -2454,7 +2454,7 @@
     },
     "cancel-token": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/cancel-token/-/cancel-token-0.1.1.tgz",
       "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
       "dev": true,
       "requires": {
@@ -2483,7 +2483,7 @@
     },
     "chai": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
@@ -2610,7 +2610,7 @@
     },
     "cleankill": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cleankill/-/cleankill-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/cleankill/-/cleankill-2.0.0.tgz",
       "integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE=",
       "dev": true
     },
@@ -2668,7 +2668,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2838,7 +2838,7 @@
     },
     "commander": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
@@ -3124,7 +3124,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -3174,7 +3174,7 @@
     },
     "deep-eql": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
       "dev": true,
       "requires": {
@@ -3348,7 +3348,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3360,7 +3360,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -3393,7 +3393,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
@@ -3421,7 +3421,7 @@
     },
     "domelementtype": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
       "dev": true
     },
@@ -3455,7 +3455,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -3713,7 +3713,7 @@
     },
     "eslint": {
       "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
@@ -3784,7 +3784,7 @@
     },
     "espree": {
       "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
@@ -3917,7 +3917,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -4086,7 +4086,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
@@ -4186,7 +4186,7 @@
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
@@ -4274,7 +4274,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -4321,7 +4321,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
           "dev": true
         }
@@ -5095,7 +5095,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -5278,7 +5278,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5291,7 +5291,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -5302,7 +5302,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -5479,7 +5479,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
           "dev": true
         },
@@ -5554,7 +5554,7 @@
     },
     "handle-thing": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+      "resolved": "http://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
       "dev": true
     },
@@ -5779,7 +5779,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -6122,7 +6122,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -6272,7 +6272,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -6656,7 +6656,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -6829,7 +6829,7 @@
     },
     "lolex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
+      "resolved": "http://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
@@ -6885,7 +6885,7 @@
     },
     "magic-string": {
       "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "resolved": "http://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
@@ -6979,7 +6979,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -7001,7 +7001,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -7019,7 +7019,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -7120,7 +7120,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -7147,7 +7147,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -7327,7 +7327,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
@@ -7365,7 +7365,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -7376,7 +7376,7 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         }
@@ -7612,7 +7612,7 @@
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "dev": true,
       "requires": {
@@ -7662,13 +7662,13 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -7677,7 +7677,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -7832,7 +7832,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -7913,7 +7913,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -8618,13 +8618,13 @@
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -8776,7 +8776,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -8805,7 +8805,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -8916,7 +8916,7 @@
     },
     "regexpp": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
       "dev": true
     },
@@ -8970,7 +8970,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -9089,7 +9089,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -9222,7 +9222,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -9389,7 +9389,7 @@
       "dependencies": {
         "debug": {
           "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
           "integrity": "sha1-zoqxte6PvuK/o7Yzyrk9NmtjQY4=",
           "dev": true,
           "requires": {
@@ -9398,7 +9398,7 @@
         },
         "depd": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
           "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo=",
           "dev": true
         },
@@ -9437,13 +9437,13 @@
         },
         "mime": {
           "version": "1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
           "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
           "dev": true
         },
         "ms": {
           "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
+          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
           "integrity": "sha1-hlvpTC5zl62KV9pqYzpuLzB5i4M=",
           "dev": true
         },
@@ -9613,7 +9613,7 @@
     },
     "sinon": {
       "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
+      "resolved": "http://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
       "dev": true,
       "requires": {
@@ -10036,7 +10036,7 @@
     },
     "stacky": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/stacky/-/stacky-1.3.1.tgz",
       "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
       "dev": true,
       "requires": {
@@ -10046,7 +10046,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10059,13 +10059,13 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -10146,7 +10146,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -10197,7 +10197,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -10329,7 +10329,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+          "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true,
           "optional": true
@@ -10369,7 +10369,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
@@ -10405,7 +10405,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -11420,7 +11420,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -11450,7 +11450,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11502,7 +11502,7 @@
     },
     "xmlbuilder": {
       "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
       "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
       "dev": true,
       "optional": true
@@ -11581,7 +11581,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/src/patch-prototypes.js
+++ b/src/patch-prototypes.js
@@ -62,11 +62,17 @@ const patchMap = {
 
 const getPatchPrototype = (name) => window[name] && window[name].prototype;
 
+// Note, must avoid patching accessors on prototypes when descriptors are not correct
+// because the CustomElements polyfill checks if these exist before patching instances.
+// CustomElements polyfill *only* cares about these accessors.
+const disallowedNativePatches = utils.settings.hasDescriptors ? null : ['innerHTML', 'textContent'];
+
 export const applyPatches = (prefix) => {
+  const disallowed = prefix ? null : disallowedNativePatches;
   for (let p in patchMap) {
     const proto = getPatchPrototype(p);
     patchMap[p].forEach(patch => proto && patch &&
-        utils.patchProperties(proto, patch, prefix));
+        utils.patchProperties(proto, patch, prefix, disallowed));
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -140,10 +140,14 @@ export const SHADY_PREFIX = '__shady_';
  * @param {!Object} obj
  * @param {!Object} descriptors
  * @param {boolean=} force
+ * @param {Array=} disallowedPatches
  */
-export const patchProperties = (proto, descriptors, prefix = '') => {
+export const patchProperties = (proto, descriptors, prefix = '', disallowedPatches) => {
   for (let p in descriptors) {
     const newDescriptor = descriptors[p];
+    if (disallowedPatches && disallowedPatches.indexOf(p) >= 0) {
+      continue;
+    }
     newDescriptor.configurable = true;
     const name = prefix + p;
     // NOTE: we prefer writing directly because some browsers

--- a/tests/shady-dynamic.html
+++ b/tests/shady-dynamic.html
@@ -97,6 +97,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
 
       Klass.prototype.connectedCallback = function() {
+        this._isDisconnected = false;
         if (!this._initialized) {
           this._initialized = true;
           if (connected) {
@@ -107,6 +108,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             ShadyDOM.wrap(ShadyDOM.wrap(this).shadowRoot).appendChild(ShadyDOM.wrap(document).importNode(template.content, true));
           }
         }
+      }
+
+      Klass.prototype.disconnectedCallback = function() {
+        this._isDisconnected = true;
       }
 
       customElements.define(name, Klass);
@@ -1373,6 +1378,22 @@ suite('Accessors', function() {
     ShadyDOM.wrap(element).innerHTML = '<div>A</div><div>B</div>';
     assert.equal(ShadyDOM.wrap(element).childNodes.length, 0);
     assert.equal(ShadyDOM.wrap(element.content).childNodes.length, 2);
+  });
+
+  test('innerHTML containing custom element', function() {
+    var testElement = document.createElement('div');
+    ShadyDOM.wrap(document.body).appendChild(testElement);
+    ShadyDOM.wrap(testElement).innerHTML = '<x-simple></x-simple>';
+    assert.isTrue(ShadyDOM.wrap(testElement).firstChild._initialized);
+  });
+
+  test('textContent that removes custom element', function() {
+    var testElement = document.createElement('div');
+    ShadyDOM.wrap(document.body).appendChild(testElement);
+    ShadyDOM.wrap(testElement).innerHTML = '<x-simple></x-simple>';
+    const el = ShadyDOM.wrap(testElement).firstChild;
+    ShadyDOM.wrap(testElement).textContent = '';
+    assert.isTrue(el._isDisconnected);
   });
 
 });


### PR DESCRIPTION
Fixes #303.

On very old browsers (Safari/Chrome) accessors do not exist on prototypes. In this case patching must occur on instances, and this changes ensures that ShadyDOM does *not* patch these accessors on native prototypes. This ensures that custom elements polyfill does not get confused and appropriately patches instances.
