### PR TITLE
Make ShadyDOM compile strictly

### DIFF
--- a/externs/shadydom.js
+++ b/externs/shadydom.js
@@ -10,18 +10,11 @@
 Element.prototype.slot;
 
 /**
- * Block renaming of properties added to Window to
- * prevent conflicts with other closure-compiler code.
- * @type {Object}
- */
-Window.prototype.__handlers;
-
-/**
  * Block renaming of properties added to Node to
  * prevent conflicts with other closure-compiler code.
  * @type {Object}
  */
-Node.prototype.__handlers;
+EventTarget.prototype.__handlers;
 
 /** @type {Object} */
 Node.prototype.__shady;
@@ -31,3 +24,28 @@ function IWrapper() {}
 
 /** @type {Object} */
 IWrapper.prototype._activeElement;
+
+// NOTE: For some reason, Closure likes to remove focus() from the IWrapper
+// class. Not yet clear why focus() is affected and not any other methods (e.g.
+// blur).
+IWrapper.prototype.focus = function() {};
+
+/** @type {!boolean|undefined} */
+Event.prototype.__composed;
+
+/** @type {!boolean|undefined} */
+Event.prototype.__immediatePropagationStopped;
+
+/** @type {!Node|undefined} */
+Event.prototype.__relatedTarget;
+
+/** @type {!Array<!EventTarget>|undefined} */
+Event.prototype.__composedPath;
+
+/** @type {!Array<!EventTarget>|undefined} */
+Event.prototype.__relatedTargetComposedPath;
+
+/**
+ * Prevent renaming of this method on ShadyRoot for testing and debugging.
+ */
+ShadowRoot.prototype._renderRoot = function(){};

--- a/src/link-nodes.js
+++ b/src/link-nodes.js
@@ -98,7 +98,6 @@ export const recordRemoveChild = (node, container) => {
 
 /**
  * @param  {!Node} node
- * @param  {Array<Node>=} nodes
  */
 export const recordChildNodes = (node) => {
   const nodeData = ensureShadyDataForNode(node);

--- a/src/patch-events.js
+++ b/src/patch-events.js
@@ -165,7 +165,7 @@ let EventPatches = {
         this.__composed = alwaysComposed[this.type];
       }
     }
-    return this.__composed || false;
+    return /** @type {!Event} */(this).__composed || false;
   },
 
   /**
@@ -175,7 +175,7 @@ let EventPatches = {
     if (!this.__composedPath) {
       this.__composedPath = pathComposer(this['__target'], this.composed);
     }
-    return this.__composedPath;
+    return /** @type {!Event} */(this).__composedPath;
   },
 
   /**
@@ -197,7 +197,7 @@ let EventPatches = {
       this.__relatedTargetComposedPath = pathComposer(this.__relatedTarget, true);
     }
     // find the deepest node in relatedTarget composed path that is in the same root with the currentTarget
-    return retarget(this.currentTarget || this['__previousCurrentTarget'], this.__relatedTargetComposedPath);
+    return retarget(this.currentTarget || this['__previousCurrentTarget'], /** @type {!Event} */(this).__relatedTargetComposedPath);
   },
   /**
    * @this {Event}
@@ -348,7 +348,7 @@ function getEventWrappers(eventLike) {
 }
 
 /**
- * @this {Event}
+ * @this {EventTarget}
  */
 export function addEventListener(type, fnOrObj, optionsOrCapture) {
   if (!fnOrObj) {
@@ -456,6 +456,7 @@ export function addEventListener(type, fnOrObj, optionsOrCapture) {
       return ret;
     }
   };
+
   // Store the wrapper information.
   fnOrObj[eventWrappersName].push({
     // note: use target here which is either a shadowRoot
@@ -479,7 +480,7 @@ export function addEventListener(type, fnOrObj, optionsOrCapture) {
 }
 
 /**
- * @this {Event}
+ * @this {EventTarget}
  */
 export function removeEventListener(type, fnOrObj, optionsOrCapture) {
   if (!fnOrObj) {

--- a/src/patch-native.js
+++ b/src/patch-native.js
@@ -18,9 +18,11 @@ export const NATIVE_PREFIX = utils.NATIVE_PREFIX;
 // e.g. `nativeMethods.querySelector.call(node, selector)`
 // same as `node.querySelector(selector)`
 export const nativeMethods = {
+  /** @this {Element} */
   querySelector(selector) {
     return this[NATIVE_PREFIX + 'querySelector'](selector);
   },
+  /** @this {Element} */
   querySelectorAll(selector) {
     return this[NATIVE_PREFIX + 'querySelectorAll'](selector);
   }
@@ -66,12 +68,15 @@ const copyProperties = (proto, list = []) => {
   }
 }
 
+/** @type {!TreeWalker} */
 const nodeWalker = document.createTreeWalker(document, NodeFilter.SHOW_ALL,
   null, false);
 
+/** @type {!TreeWalker} */
 const elementWalker = document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT,
   null, false);
 
+/** @type {!Document} */
 const inertDoc = document.implementation.createHTMLDocument('inert');
 
 const clearNode = node => {
@@ -125,18 +130,21 @@ export const addNativePrefixedProperties = () => {
   } else {
     defineNativeAccessors(Node.prototype, {
       parentNode: {
+        /** @this {Node} */
         get() {
           nodeWalker.currentNode = this;
           return nodeWalker.parentNode();
         }
       },
       firstChild: {
+        /** @this {Node} */
         get() {
           nodeWalker.currentNode = this;
           return nodeWalker.firstChild();
         }
       },
       lastChild: {
+        /** @this {Node} */
         get() {
           nodeWalker.currentNode = this;
           return nodeWalker.lastChild();
@@ -144,12 +152,14 @@ export const addNativePrefixedProperties = () => {
 
       },
       previousSibling: {
+        /** @this {Node} */
         get() {
           nodeWalker.currentNode = this;
           return nodeWalker.previousSibling();
         }
       },
       nextSibling: {
+        /** @this {Node} */
         get() {
           nodeWalker.currentNode = this;
           return nodeWalker.nextSibling();
@@ -157,6 +167,7 @@ export const addNativePrefixedProperties = () => {
       },
       // TODO(sorvell): make this a NodeList or whatever
       childNodes: {
+        /** @this {Node} */
         get() {
           const nodes = [];
           nodeWalker.currentNode = this;
@@ -169,12 +180,14 @@ export const addNativePrefixedProperties = () => {
         }
       },
       parentElement: {
+        /** @this {Node} */
         get() {
           elementWalker.currentNode = this;
           return elementWalker.parentNode();
         }
       },
       textContent: {
+        /** @this {Node} */
         get() {
           /* eslint-disable no-case-declarations */
           switch (this.nodeType) {
@@ -196,6 +209,7 @@ export const addNativePrefixedProperties = () => {
           }
         },
         // Needed on browsers that do not proper accessors (e.g. old versions of Chrome)
+        /** @this {Node} */
         set(value) {
           if (typeof value === 'undefined' || value === null) {
             value = ''
@@ -231,18 +245,21 @@ export const addNativePrefixedProperties = () => {
 
   const ParentNodeWalkerDescriptors = {
     firstElementChild: {
+      /** @this {ParentNode} */
       get() {
         elementWalker.currentNode = this;
         return elementWalker.firstChild();
       }
     },
     lastElementChild: {
+      /** @this {ParentNode} */
       get() {
         elementWalker.currentNode = this;
         return elementWalker.lastChild();
       }
     },
     children: {
+      /** @this {ParentNode} */
       get() {
         let nodes = [];
         elementWalker.currentNode = this;
@@ -255,6 +272,7 @@ export const addNativePrefixedProperties = () => {
       }
     },
     childElementCount: {
+      /** @this {ParentNode} */
       get() {
         return this.children.length;
       }
@@ -286,22 +304,26 @@ export const addNativePrefixedProperties = () => {
     defineNativeAccessors(Element.prototype, ParentNodeWalkerDescriptors);
     defineNativeAccessors(Element.prototype, {
       previousElementSibling: {
+        /** @this {Element} */
         get() {
           elementWalker.currentNode = this;
           return elementWalker.previousSibling();
         }
       },
       nextElementSibling: {
+        /** @this {Element} */
         get() {
           elementWalker.currentNode = this;
           return elementWalker.nextSibling();
         }
       },
       innerHTML: {
+        /** @this {Element} */
         get() {
           return getInnerHTML(this, n => n[NATIVE_PREFIX + 'childNodes']);
         },
         // Needed on browsers that do not proper accessors (e.g. old versions of Chrome)
+        /** @this {Element} */
         set(value) {
           const content = this.localName === 'template' ?
           /** @type {HTMLTemplateElement} */(this).content : this;

--- a/src/patch-prototypes.js
+++ b/src/patch-prototypes.js
@@ -67,6 +67,7 @@ const getPatchPrototype = (name) => window[name] && window[name].prototype;
 // CustomElements polyfill *only* cares about these accessors.
 const disallowedNativePatches = utils.settings.hasDescriptors ? null : ['innerHTML', 'textContent'];
 
+/** @param {string=} prefix */
 export const applyPatches = (prefix) => {
   const disallowed = prefix ? null : disallowedNativePatches;
   for (let p in patchMap) {

--- a/src/patch-shadyRoot.js
+++ b/src/patch-shadyRoot.js
@@ -17,6 +17,10 @@ import {DocumentOrShadowRootPatches} from './patches/DocumentOrShadowRoot.js';
 import {ElementOrShadowRootPatches} from './patches/ElementOrShadowRoot.js';
 import {ShadowRootPatches} from './patches/ShadowRoot.js';
 
+/**
+ * @param {!Object} proto
+ * @param {string=} prefix
+ */
 const patchShadyAccessors = (proto, prefix) => {
   utils.patchProperties(proto, ShadowRootPatches, prefix);
   utils.patchProperties(proto, DocumentOrShadowRootPatches, prefix);
@@ -87,6 +91,7 @@ export const patchShadyRoot = (proto) => {
     'isConnected'
   ].forEach((prop) => {
     Object.defineProperty(proto, prop, {
+      /** @this {ShadowRoot} */
       get() {
         return this.host[prop];
       },

--- a/src/patches/DocumentOrShadowRoot.js
+++ b/src/patches/DocumentOrShadowRoot.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import * as utils from '../utils.js';
+import {ownerShadyRootForNode} from '../attach-shadow.js';
 
 function getDocumentActiveElement() {
   if (utils.settings.hasDescriptors) {
@@ -47,10 +48,10 @@ export const DocumentOrShadowRootPatches = utils.getOwnPropertyDescriptors({
     // This node is either the document or a shady root of which the active
     // element is a (composed) descendant of its host; iterate upwards to
     // find the active element's most shallow host within it.
-    let activeRoot = utils.ownerShadyRootForNode(active);
+    let activeRoot = ownerShadyRootForNode(active);
     while (activeRoot && activeRoot !== this) {
       active = activeRoot.host;
-      activeRoot = utils.ownerShadyRootForNode(active);
+      activeRoot = ownerShadyRootForNode(active);
     }
     if (this === document) {
       // This node is the document, so activeRoot should be null.

--- a/src/patches/Element.js
+++ b/src/patches/Element.js
@@ -11,7 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 import * as utils from '../utils.js';
 import {scopeClassAttribute} from '../style-scoping.js';
 import {shadyDataForNode} from '../shady-data.js';
-import {attachShadow} from '../attach-shadow.js';
+import {attachShadow, ownerShadyRootForNode} from '../attach-shadow.js';
 
 const doc = window.document;
 
@@ -29,7 +29,7 @@ function distributeAttributeChange(node, name) {
       shadyDataForNode(parent).root._asyncRender();
     }
   } else if (node.localName === 'slot' && name === 'name') {
-    let root = utils.ownerShadyRootForNode(node);
+    let root = ownerShadyRootForNode(node);
     if (root) {
       root._updateSlotName(node);
       root._asyncRender();
@@ -124,7 +124,7 @@ export const ElementPatches = utils.getOwnPropertyDescriptors({
 
   /**
    * @this {Element}
-   * @param {object} options
+   * @param {!{mode: string}} options
    */
   attachShadow(options) {
     return attachShadow(this, options);

--- a/src/patches/ElementOrShadowRoot.js
+++ b/src/patches/ElementOrShadowRoot.js
@@ -12,6 +12,7 @@ import * as utils from '../utils.js';
 import {getInnerHTML} from '../innerHTML.js';
 import {clearNode} from './Node.js';
 
+/** @type {!Document} */
 const inertDoc = document.implementation.createHTMLDocument('inert');
 
 export const ElementOrShadowRootPatches = utils.getOwnPropertyDescriptors({

--- a/src/patches/Node.js
+++ b/src/patches/Node.js
@@ -13,6 +13,7 @@ import {getScopingShim, removeShadyScoping, replaceShadyScoping,
   treeVisitor, currentScopeForNode, currentScopeIsCorrect } from '../style-scoping.js';
 import {shadyDataForNode, ensureShadyDataForNode} from '../shady-data.js';
 import {recordInsertBefore, recordRemoveChild} from '../link-nodes.js';
+import {ownerShadyRootForNode} from '../attach-shadow.js';
 
 const doc = window.document;
 
@@ -264,8 +265,7 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     }
     /** @type {!Array<!HTMLSlotElement>} */
     const slotsAdded = [];
-    /** @type {function(!Node, string): void} */
-    const ownerRoot = utils.ownerShadyRootForNode(this);
+    const ownerRoot = ownerShadyRootForNode(this);
     /** @type {string} */
     const newScopeName = ownerRoot ? ownerRoot.host.localName : currentScopeForNode(this);
     /** @type {string} */
@@ -275,7 +275,7 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     if (parentNode) {
       oldScopeName = currentScopeForNode(node);
       parentNode[utils.SHADY_PREFIX + 'removeChild'](node,
-        Boolean(ownerRoot) || !utils.ownerShadyRootForNode(node));
+        Boolean(ownerRoot) || !ownerShadyRootForNode(node));
     }
     // add to new parent
     let allowNativeInsert = true;
@@ -376,7 +376,7 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
         node);
     }
     let preventNativeRemove;
-    let ownerRoot = utils.ownerShadyRootForNode(node);
+    let ownerRoot = ownerShadyRootForNode(node);
     let removingInsertionPoint;
     const parentData = shadyDataForNode(this);
     if (utils.isTrackingLogicalChildNodes(this)) {
@@ -459,7 +459,7 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
   },
 
   /**
-   * @param {Node} this
+   * @this {Node}
    * @param {Object=} options
    */
   // TODO(sorvell): implement `options` e.g. `{ composed: boolean }`
@@ -490,7 +490,7 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     return root;
   },
 
-  /** @param {Node} this */
+  /** @this {Node} */
   contains(node) {
     return utils.contains(this, node);
   }

--- a/src/patches/ShadowRoot.js
+++ b/src/patches/ShadowRoot.js
@@ -15,8 +15,8 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
   /**
    * @this {ShadowRoot}
    * @param {string} type
-   * @param {function} fn
-   * @param {object|boolean} optionsOrCapture
+   * @param {Function} fn
+   * @param {Object|boolean=} optionsOrCapture
    */
   addEventListener(type, fn, optionsOrCapture) {
     if (typeof optionsOrCapture !== 'object') {
@@ -31,8 +31,8 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
   /**
    * @this {ShadowRoot}
    * @param {string} type
-   * @param {function} fn
-   * @param {object|boolean} optionsOrCapture
+   * @param {Function} fn
+   * @param {Object|boolean=} optionsOrCapture
    */
   removeEventListener(type, fn, optionsOrCapture) {
     if (typeof optionsOrCapture !== 'object') {

--- a/src/patches/Slot.js
+++ b/src/patches/Slot.js
@@ -15,7 +15,7 @@ export const SlotPatches = utils.getOwnPropertyDescriptors({
 
   /**
    * @this {HTMLSlotElement}
-   * @param {object} options
+   * @param {Object=} options
    */
   assignedNodes(options) {
     if (this.localName === 'slot') {

--- a/src/patches/Slotable.js
+++ b/src/patches/Slotable.js
@@ -13,6 +13,7 @@ import {shadyDataForNode} from '../shady-data.js';
 
 export const SlotablePatches = utils.getOwnPropertyDescriptors({
 
+  /** @this {Node} */
   get assignedSlot() {
     // Force any parent's shadowRoot to flush so that distribution occurs
     // and this node has an assignedSlot.

--- a/src/shady-data.js
+++ b/src/shady-data.js
@@ -45,6 +45,7 @@ export class ShadyData {
     this.__onCallbackListeners = {};
   }
 
+  /** @override */
   toJSON() {
     return {};
   }

--- a/src/shadydom.js
+++ b/src/shadydom.js
@@ -125,5 +125,5 @@ if (utils.settings.inUse) {
   // (e.g. `ShadyDOM.wrap(element).addEventListener(...)`).
   patchEvents();
 
-  window.ShadowRoot = ShadyRoot;
+  window.ShadowRoot = /** @type {function(new:ShadowRoot)} */(ShadyRoot);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 import {shadyDataForNode} from './shady-data.js';
 
+/** @type {!Object} */
 export const settings = window['ShadyDOM'] || {};
 
 settings.hasNativeShadowDOM = Boolean(Element.prototype.attachShadow && Node.prototype.getRootNode);
@@ -27,13 +28,6 @@ export const isTrackingLogicalChildNodes = (node) => {
 
 export const isShadyRoot = (obj) => {
   return Boolean(obj._localName === 'ShadyRoot');
-}
-
-export const ownerShadyRootForNode = (node) => {
-  let root = node[SHADY_PREFIX + 'getRootNode']();
-  if (isShadyRoot(root)) {
-    return root;
-  }
 }
 
 export const hasShadowRootWithSlot = (node) => {
@@ -134,12 +128,13 @@ export const NATIVE_PREFIX = '__shady_native_';
 export const SHADY_PREFIX = '__shady_';
 
 
-// patch a group of accessors on an object only if it exists or if the `force`
-// argument is true.
+
 /**
- * @param {!Object} obj
+ * Patch a group of accessors on an object only if it exists or if the `force`
+ * argument is true.
+ * @param {!Object} proto
  * @param {!Object} descriptors
- * @param {boolean=} force
+ * @param {string=} prefix
  * @param {Array=} disallowedPatches
  */
 export const patchProperties = (proto, descriptors, prefix = '', disallowedPatches) => {
@@ -166,11 +161,13 @@ export const patchProperties = (proto, descriptors, prefix = '', disallowedPatch
   }
 }
 
+/** @type {!function(new:HTMLElement)} */
 export const NativeHTMLElement =
     (window['customElements'] && window['customElements']['nativeHTMLElement']) ||
     HTMLElement;
 
 // note, this is not a perfect polyfill since it doesn't include symbols
+/** @return {!Object<!ObjectPropertyDescriptor>} */
 export const getOwnPropertyDescriptors = (obj) => {
   const descriptors = {};
   Object.getOwnPropertyNames(obj).forEach((name) => {

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -14,6 +14,7 @@ import {eventPropertyNames} from './patch-events.js';
 /** @implements {IWrapper} */
 class Wrapper {
 
+  /** @param {!Node} node */
   constructor(node) {
     this.node = node;
   }
@@ -82,6 +83,7 @@ class Wrapper {
     return this.node[utils.SHADY_PREFIX + 'attachShadow'](options);
   }
 
+  /** @return {!Node|undefined} */
   get activeElement() {
     if (utils.isShadyRoot(this.node) || this.node.nodeType === Node.DOCUMENT_NODE) {
       const e = this.node[utils.SHADY_PREFIX + 'activeElement'];
@@ -89,14 +91,19 @@ class Wrapper {
     }
   }
 
-  // Installed for compatibility with browsers (older Chrome/Safari) that do
-  // not have a configurable `activeElement` accessor. Enables noPatch and
-  // patch mode both to consistently use ShadyDOM.wrap(document)._activeElement.
+  /**
+   * Installed for compatibility with browsers (older Chrome/Safari) that do
+   * not have a configurable `activeElement` accessor. Enables noPatch and
+   * patch mode both to consistently use ShadyDOM.wrap(document)._activeElement.
+   * @override
+   * @return {!Node|undefined}
+   */
   get _activeElement() {
     return this.activeElement;
   }
 
   // NOTE: not needed, just here for balance
+  /** @override */
   focus() {
     this.node[utils.NATIVE_PREFIX + 'focus']();
   }
@@ -136,7 +143,7 @@ class Wrapper {
 
   get host() {
     if (utils.isShadyRoot(this.node)) {
-      return this.node.host;
+      return /** @type {!ShadowRoot} */(this.node).host;
     }
   }
 
@@ -232,9 +239,11 @@ class Wrapper {
 
 eventPropertyNames.forEach(name => {
   Object.defineProperty(Wrapper.prototype, name, {
+    /** @this {Wrapper} */
     get() {
       return this.node[utils.SHADY_PREFIX + name];
     },
+    /** @this {Wrapper} */
     set(value) {
       this.node[utils.SHADY_PREFIX + name] = value;
     },


### PR DESCRIPTION
The only code change was to move ownerShadyRootForNode from utils.js into attach-shadow.js, so that it can access the ShadyRoot type as its return type, without introducing a circular dependency or unnecessary externs.