### PR TITLE
Make childElementCount null-safe

### DIFF
--- a/src/patch-native.js
+++ b/src/patch-native.js
@@ -274,7 +274,10 @@ export const addNativePrefixedProperties = () => {
     childElementCount: {
       /** @this {ParentNode} */
       get() {
-        return this.children.length;
+        if (this.children) {
+          return this.children.length;
+        }
+        return 0;
       }
     }
   };

--- a/src/patches/ParentNode.js
+++ b/src/patches/ParentNode.js
@@ -88,7 +88,11 @@ export const ParentNodePatches = utils.getOwnPropertyDescriptors({
 
   /** @this {Element} */
   get childElementCount() {
-    return this[utils.SHADY_PREFIX + 'children'].length;
+    let children = this[utils.SHADY_PREFIX + 'children'];
+    if(children) {
+      return children.length;
+    }
+    return 0;
   }
 
 });

--- a/tests/shady-dynamic.html
+++ b/tests/shady-dynamic.html
@@ -34,6 +34,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
+  <svg id="emptySvg"></svg>
+
   <x-test></x-test>
 
   <x-test-esc></x-test-esc>
@@ -753,6 +755,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     assert.equal(ShadyDOM.wrap(rere).childElementCount, 1);
     var projected = ShadyDOM.wrap(ShadyDOM.wrap(test).shadowRoot).querySelector('#projected');
     assert.equal(ShadyDOM.wrap(projected).childElementCount, 0);
+    var emptySvg = ShadyDOM.wrap(document).querySelector('#emptySvg');
+    assert.equal(ShadyDOM.wrap(emptySvg).childElementCount, 0);
   });
 
   test('cloneNode shallow', function() {


### PR DESCRIPTION
This small change fixes the [#302](https://github.com/webcomponents/shadydom/issues/302) issue.