### PR TITLE
Capture native ParentNode accessors on Document

### DIFF
--- a/src/patch-native.js
+++ b/src/patch-native.js
@@ -397,7 +397,7 @@ export const addNativePrefixedProperties = () => {
 
   // Document
   if (hasDescriptors) {
-    copyProperties(DocumentFragment.prototype, ParentNodeAccessors);
+    copyProperties(Document.prototype, ParentNodeAccessors);
     copyProperties(Document.prototype, [
       'activeElement'
     ]);

--- a/tests/shady-dynamic.html
+++ b/tests/shady-dynamic.html
@@ -1254,6 +1254,17 @@ suite('Accessors', function() {
     assert.equal(ShadyDOM.wrap(element).previousElementSibling, null, 'previousElementSibling incorrect');
   });
 
+  test('document accessors', function() {
+    const doc = ShadyDOM.wrap(document);
+    assert.ok(doc.firstChild);
+    assert.ok(doc.lastChild);
+    assert.equal(doc.firstElementChild, document.documentElement);
+    assert.equal(doc.lastElementChild, document.documentElement);
+    assert.equal(doc.children.length, 1);
+    assert.equal(doc.children[0], document.documentElement);
+    assert.equal(doc.childElementCount, 1);
+  });
+
   test('template accessors (innerHTML)', function() {
     var template = document.createElement('template');
     ShadyDOM.wrap(template).innerHTML = '<div></div>';

--- a/tests/shady-dynamic.html
+++ b/tests/shady-dynamic.html
@@ -16,7 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     window.NATIVE = {
       children: Object.getOwnPropertyDescriptor(Element.prototype, 'children')
-             || Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'children')
+             || Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'children'),
+      documentHasParentNodeAccessors: Object.getOwnPropertyDescriptor(Document.prototype, 'firstElementChild')
     };
   </script>
   <script src="loader.js"></script>
@@ -1254,7 +1255,10 @@ suite('Accessors', function() {
     assert.equal(ShadyDOM.wrap(element).previousElementSibling, null, 'previousElementSibling incorrect');
   });
 
-  test('document accessors', function() {
+  test('document ParentNode accessors', function() {
+    if (!window.NATIVE.documentHasParentNodeAccessors) {
+      this.skip();
+    }
     const doc = ShadyDOM.wrap(document);
     assert.ok(doc.firstChild);
     assert.ok(doc.lastChild);


### PR DESCRIPTION
Fixes #307. `ParentNode` accessors should now work on `document` (e.g. `firstElementChild`).

Fixes a typo that prevented storing native accessors at the ShadyDOM native location (e.g. `__shady_native_firstElementChild`). This was causing, for example, `document.firstElementChild` to be undefined because the patched `firstElementChild` returns the captured native value.
