### PR TITLE
Ensure `className` applies style scoping on IE

### DIFF
--- a/src/patch-prototypes.js
+++ b/src/patch-prototypes.js
@@ -41,6 +41,10 @@ if (Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'innerHTML')) {
   NonStandardHTMLElement.innerHTML = ElementOrShadowRootPatches.innerHTML;
 }
 
+if (Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'className')) {
+  NonStandardHTMLElement.className = ElementPatches.className;
+}
+
 // Avoid patching `innerHTML` if it does not exist on Element (IE)
 // and we can patch accessors (hasDescriptors).
 const ElementShouldHaveInnerHTML = !utils.settings.hasDescriptors || 'innerHTML' in Element.prototype;

--- a/tests/smoke/property-info.html
+++ b/tests/smoke/property-info.html
@@ -35,7 +35,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     'assignedSlot',
     'slot',
     'shadowRoot',
-    'childElementCount'
+    'childElementCount',
+    'className'
   ];
   var methods = [
     'appendChild',

--- a/tests/sync-style-scoping.html
+++ b/tests/sync-style-scoping.html
@@ -276,6 +276,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(span);
           assert.equal(csfn(span), 'naive-element');
         });
+
+        test('`setAttribute(\'class\', ...)` scopes correctly', function() {
+          const el = document.createElement('naive-element');
+          const span = document.createElement('span');
+          ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(span);
+          span.setAttribute('class', 'foo');
+          assert.equal(csfn(span), 'naive-element');
+        });
+
+        test('`className` scopes correctly', function() {
+          const el = document.createElement('naive-element');
+          const span = document.createElement('span');
+          ShadyDOM.wrap(ShadyDOM.wrap(el).shadowRoot).appendChild(span);
+          span.className = 'foo';
+          assert.equal(csfn(span), 'naive-element');
+        });
       });
 
       suite('remove', function() {


### PR DESCRIPTION
Fixes #314.

Writes `className` on `HTMLElement` on browsers when needed.
