### PR TITLE
Adds `attachShadow({shadyUpgradeFragment: documentFragment})`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5283,7 +5283,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5302,7 +5302,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5266,19 +5266,24 @@
       }
     },
     "google-closure-compiler": {
-      "version": "20180506.0.0",
-      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20180506.0.0.tgz",
-      "integrity": "sha1-9ZzDTb+Mmk9I+6Prss8JjSXjRas=",
+      "version": "20190121.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20190121.0.0.tgz",
+      "integrity": "sha512-FIp3+KxjtDwykDTr1WsFo0QexEopAC4bDXXZfnEdgHECF7hCeFAAsLUPxMmj9Wx+O39eFCXGAzY7w0k5aU9qjg==",
       "dev": true,
       "requires": {
         "chalk": "^1.0.0",
+        "google-closure-compiler-java": "^20190121.0.0",
+        "google-closure-compiler-js": "^20190121.0.0",
+        "google-closure-compiler-linux": "^20190121.0.0",
+        "google-closure-compiler-osx": "^20190121.0.0",
+        "minimist": "^1.2.0",
         "vinyl": "^2.0.1",
         "vinyl-sourcemaps-apply": "^0.2.0"
       },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5289,9 +5294,15 @@
             "supports-color": "^2.0.0"
           }
         },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -5299,6 +5310,32 @@
           }
         }
       }
+    },
+    "google-closure-compiler-java": {
+      "version": "20190121.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-java/-/google-closure-compiler-java-20190121.0.0.tgz",
+      "integrity": "sha512-UCQ7ZXOlk/g101DS4TqyW+SaoR+4GVq7NKrwebH4gnESY76Xuz7FRrKWwfAXwltmiYAUVZCVI4qpoEz48V+VjA==",
+      "dev": true
+    },
+    "google-closure-compiler-js": {
+      "version": "20190121.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20190121.0.0.tgz",
+      "integrity": "sha512-PgY0Fy+fXZnjir6aPz/FVJPXuwZf5pKJ9n7Hf1HL4x1lhqVIf3i+u3Ed6ZWCXa+YiEhvwH5RTQr/iPP/D3gDRg==",
+      "dev": true
+    },
+    "google-closure-compiler-linux": {
+      "version": "20190121.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20190121.0.0.tgz",
+      "integrity": "sha512-cw4qr9TuB2gB53l/oYadZLuw+zOi2yggYFtnNA5jvTLTqY8m2VZAL5DGL6gmCtZovbQ0bv9ANqjT8NxEtcSzfw==",
+      "dev": true,
+      "optional": true
+    },
+    "google-closure-compiler-osx": {
+      "version": "20190121.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20190121.0.0.tgz",
+      "integrity": "sha512-6OqyUcgojPCqCuzdyKLwmIkBhfoWF3cVzaX8vaJvQ3SYwlITBT3aepMEZiWFRVvvml+ojs1AJcZvQIqFke8X1w==",
+      "dev": true,
+      "optional": true
     },
     "got": {
       "version": "6.7.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@webcomponents/webcomponents-platform": "^1.0.0",
     "eslint": "^4.19.1",
     "eslint-plugin-html": "^4.0.5",
-    "google-closure-compiler": "^20180506.0.0",
+    "google-closure-compiler": "^20190121.0.0",
     "gulp": "^4.0.0",
     "gulp-rename": "^1.4.0",
     "gulp-rollup": "^2.16.2",

--- a/src/attach-shadow.js
+++ b/src/attach-shadow.js
@@ -652,10 +652,8 @@ if (window['customElements'] && utils.settings.inUse && !utils.settings['preferP
   }
 
   const define = window['customElements']['define'];
-  // NOTE: Instead of patching customElements.define,
-  // re-define on the CustomElementRegistry.prototype.define
-  // for Safari 10 compatibility (it's flakey otherwise).
-  //Object.defineProperty(window['CustomElementRegistry'].prototype, 'define', {
+  // Note, it would be better to patch the CustomElementRegistry.prototype, but
+  // ShadyCSS patches define directly.
   window.customElements.define = function(name, constructor) {
       const connected = constructor.prototype.connectedCallback;
       const disconnected = constructor.prototype.disconnectedCallback;

--- a/src/attach-shadow.js
+++ b/src/attach-shadow.js
@@ -56,25 +56,25 @@ class ShadyRoot {
     this._slotMap;
     /** @type {?Array<HTMLSlotElement>} */
     this._pendingSlots;
-    this._init(this, host, options);
+    this._init(host, options);
   }
 
-  _init(root, host, options) {
+  _init(host, options) {
     // NOTE: set a fake local name so this element can be
     // distinguished from a DocumentFragment when patching.
     // FF doesn't allow this to be `localName`
-    root._localName = SHADYROOT_NAME;
+    this._localName = SHADYROOT_NAME;
     // root <=> host
-    root.host = host;
+    this.host = host;
     /** @type {!string|undefined} */
-    root.mode = options && options.mode;
+    this.mode = options && options.mode;
     recordChildNodes(host);
     const hostData = ensureShadyDataForNode(host);
     /** @type {!ShadyRoot} */
-    hostData.root = root;
-    hostData.publicRoot = root.mode !== MODE_CLOSED ? root : null;
+    hostData.root = this;
+    hostData.publicRoot = this.mode !== MODE_CLOSED ? this : null;
     // setup root
-    const rootData = ensureShadyDataForNode(root);
+    const rootData = ensureShadyDataForNode(this);
     rootData.firstChild = rootData.lastChild =
         rootData.parentNode = rootData.nextSibling =
         rootData.previousSibling = null;
@@ -86,7 +86,7 @@ class ShadyRoot {
         host[utils.NATIVE_PREFIX + 'removeChild'](n);
       }
     } else {
-      root._asyncRender();
+      this._asyncRender();
     }
   }
 

--- a/src/attach-shadow.js
+++ b/src/attach-shadow.js
@@ -366,7 +366,7 @@ class ShadyRoot {
 
   // Ensures that the rendered node list inside `container` is `children`.
   _updateChildNodes(container, children) {
-    let composed = Array.prototype.slice.call(container[utils.NATIVE_PREFIX + 'childNodes']);
+    let composed = utils.nativeChildNodesArray(container);
     let splices = calculateSplices(children, composed);
     // process removals
     for (let i=0, d=0, s; (i<splices.length) && (s=splices[i]); i++) {
@@ -465,7 +465,7 @@ class ShadyRoot {
         let nA = listA[i];
         let nB = listB[i];
         if (nA !== nB) {
-          let c$ = Array.from(nA[utils.SHADY_PREFIX + 'parentNode'][utils.SHADY_PREFIX + 'childNodes']);
+          let c$ = utils.childNodesArray(nA[utils.SHADY_PREFIX + 'parentNode']);
           return c$.indexOf(nA) - c$.indexOf(nB);
         }
       }

--- a/src/attach-shadow.js
+++ b/src/attach-shadow.js
@@ -122,10 +122,8 @@ class ShadyRoot {
   _rendererForHost() {
     let root = this.host[utils.SHADY_PREFIX + 'getRootNode']();
     if (utils.isShadyRoot(root)) {
-      let c$ = this.host[utils.SHADY_PREFIX + 'childNodes'];
-      for (let i=0, c; i < c$.length; i++) {
-        c = c$[i];
-        if (this._isInsertionPoint(c)) {
+      for (let n=this.host[utils.SHADY_PREFIX + 'firstChild']; n; n = n[utils.SHADY_PREFIX + 'nextSibling']) {
+        if (this._isInsertionPoint(n)) {
           return root;
         }
       }
@@ -161,13 +159,11 @@ class ShadyRoot {
     // if optimization flag is not set.
     // on initial render remove any undistributed children.
     if (!utils.settings['preferPerformance'] && !this._hasRendered) {
-      const c$ = this.host[utils.SHADY_PREFIX + 'childNodes'];
-      for (let i=0, l=c$.length; i < l; i++) {
-        const child = c$[i];
-        const data = shadyDataForNode(child);
-        if (child[utils.NATIVE_PREFIX + 'parentNode'] === this.host &&
-            (child.localName === 'slot' || !data.assignedSlot)) {
-          this.host[utils.NATIVE_PREFIX + 'removeChild'](child);
+      for (let n=this.host[utils.SHADY_PREFIX + 'firstChild']; n; n = n[utils.SHADY_PREFIX + 'nextSibling']) {
+        const data = shadyDataForNode(n);
+        if (n[utils.NATIVE_PREFIX + 'parentNode'] === this.host &&
+            (n.localName === 'slot' || !data.assignedSlot)) {
+          this.host[utils.NATIVE_PREFIX + 'removeChild'](n);
         }
       }
     }
@@ -347,20 +343,18 @@ class ShadyRoot {
   // Returns the list of nodes which should be rendered inside `node`.
   _composeNode(node) {
     let children = [];
-    let c$ = node[utils.SHADY_PREFIX + 'childNodes'];
-    for (let i = 0; i < c$.length; i++) {
-      let child = c$[i];
+    for (let n=node[utils.SHADY_PREFIX + 'firstChild']; n; n = n[utils.SHADY_PREFIX + 'nextSibling']) {
       // Note: if we see a slot here, the nodes are guaranteed to need to be
       // composed here. This is because if there is redistribution, it has
       // already been handled by this point.
-      if (this._isInsertionPoint(child)) {
-        let flattenedNodes = shadyDataForNode(child).flattenedNodes;
+      if (this._isInsertionPoint(n)) {
+        let flattenedNodes = shadyDataForNode(n).flattenedNodes;
         for (let j = 0; j < flattenedNodes.length; j++) {
           let distributedNode = flattenedNodes[j];
             children.push(distributedNode);
         }
       } else {
-        children.push(child);
+        children.push(n);
       }
     }
     return children;

--- a/src/attach-shadow.js
+++ b/src/attach-shadow.js
@@ -42,13 +42,6 @@ function ancestorList(node) {
  */
 class ShadyRoot {
 
-  static ['upgrade'](fragment, host, options) {
-    fragment.__proto__ = ShadowRoot.prototype;
-    fragment._init(fragment, host, options);
-    fragment['_attachDom'](fragment);
-    return fragment;
-  }
-
   constructor(token, host, options) {
     if (token !== ShadyRootConstructionToken) {
       throw new TypeError('Illegal constructor');
@@ -57,11 +50,11 @@ class ShadyRoot {
     this._renderPending;
     /** @type {boolean} */
     this._hasRendered;
-    /** @type {Array<HTMLSlotElement>>} */
+    /** @type {?Array<HTMLSlotElement>} */
     this._slotList = null;
-    /** @type {Object<string, Array<HTMLSlotElement>>} */
+    /** @type {?Object<string, Array<HTMLSlotElement>>} */
     this._slotMap;
-    /** @type {Array<HTMLSlotElement>>} */
+    /** @type {?Array<HTMLSlotElement>} */
     this._pendingSlots;
     this._init(this, host, options);
   }

--- a/src/link-nodes.js
+++ b/src/link-nodes.js
@@ -53,6 +53,9 @@ export const recordInsertBefore = (node, container, ref_node) => {
   }
   // handle document fragments
   if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+    // Note, documentFragments should not have logical DOM so there's
+    // no need update that. It is possible to append a ShadowRoot, but we're
+    // choosing not to support that.
     const first = node[utils.NATIVE_PREFIX + 'firstChild'];
     for (let n = first; n; (n = n[utils.NATIVE_PREFIX + 'nextSibling'])) {
       linkNode(n, container, containerData, ref_node);

--- a/src/link-nodes.js
+++ b/src/link-nodes.js
@@ -91,8 +91,8 @@ export const recordRemoveChild = (node, container) => {
 }
 
 /**
- * @param  {!Node} node
- * @param  {!Node=} root
+ * @param  {!Node|DocumentFragment} node
+ * @param  {!Node|DocumentFragment=} root
  */
 export const recordChildNodes = (node, root) => {
   const nodeData = ensureShadyDataForNode(node);

--- a/src/link-nodes.js
+++ b/src/link-nodes.js
@@ -53,7 +53,7 @@ export const recordInsertBefore = (node, container, ref_node) => {
   }
   // handle document fragments
   if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
-    const first = node[utils.NATIVE_PREFIX + 'firstChild'] || null;
+    const first = node[utils.NATIVE_PREFIX + 'firstChild'];
     for (let n = first; n; (n = n[utils.NATIVE_PREFIX + 'nextSibling'])) {
       linkNode(n, container, containerData, ref_node);
     }
@@ -92,23 +92,22 @@ export const recordRemoveChild = (node, container) => {
 
 /**
  * @param  {!Node|DocumentFragment} node
- * @param  {!Node|DocumentFragment=} root
+ * @param  {!Node|DocumentFragment=} adoptedParent
  */
-export const recordChildNodes = (node, root) => {
+export const recordChildNodes = (node, adoptedParent) => {
   const nodeData = ensureShadyDataForNode(node);
-  if (!root && nodeData.firstChild !== undefined) {
+  if (!adoptedParent && nodeData.firstChild !== undefined) {
     return;
   }
-  root = root || node;
   // remove caching of childNodes
   nodeData.childNodes = null;
-  const first = nodeData.firstChild = node[utils.NATIVE_PREFIX + 'firstChild'] || null;
-  nodeData.lastChild = node[utils.NATIVE_PREFIX + 'lastChild'] || null;
+  const first = nodeData.firstChild = node[utils.NATIVE_PREFIX + 'firstChild'];
+  nodeData.lastChild = node[utils.NATIVE_PREFIX + 'lastChild'];
   patchInsideElementAccessors(node);
   for (let n = first, previous; n; (n = n[utils.NATIVE_PREFIX + 'nextSibling'])) {
     const sd = ensureShadyDataForNode(n);
-    sd.parentNode = root;
-    sd.nextSibling = n[utils.NATIVE_PREFIX + 'nextSibling'] || null;
+    sd.parentNode = adoptedParent || node;
+    sd.nextSibling = n[utils.NATIVE_PREFIX + 'nextSibling'];
     sd.previousSibling = previous || null;
     previous = n;
     patchOutsideElementAccessors(n);

--- a/src/patch-events.js
+++ b/src/patch-events.js
@@ -440,7 +440,7 @@ export function addEventListener(type, fnOrObj, optionsOrCapture) {
   const wrapperFn = function(e) {
     // Support `once` option.
     if (once) {
-      this[utils.SHADY_PREFIX + 'removeEventListener'](type, fnOrObj, nativeEventOptions);
+      this[utils.SHADY_PREFIX + 'removeEventListener'](type, fnOrObj, optionsOrCapture);
     }
     if (!e['__target']) {
       patchEvent(e);

--- a/src/patch-native.js
+++ b/src/patch-native.js
@@ -323,7 +323,7 @@ export const addNativePrefixedProperties = () => {
       innerHTML: {
         /** @this {Element} */
         get() {
-          return getInnerHTML(this, n => n[NATIVE_PREFIX + 'childNodes']);
+          return getInnerHTML(this, utils.nativeChildNodesArray);
         },
         // Needed on browsers that do not proper accessors (e.g. old versions of Chrome)
         /** @this {Element} */

--- a/src/patch-native.js
+++ b/src/patch-native.js
@@ -62,7 +62,6 @@ const copyProperties = (proto, list = []) => {
         installNativeMethod(name, descriptor.value);
       } else {
         installNativeAccessor(name);
-
       }
     }
   }
@@ -243,6 +242,12 @@ export const addNativePrefixedProperties = () => {
     'contains'
   ]);
 
+  // NOTE, on some browsers IE 11 / Edge 15 some properties are incorrectly on HTMLElement
+  copyProperties(HTMLElement.prototype, [
+    'parentElement',
+    'contains'
+  ]);
+
   const ParentNodeWalkerDescriptors = {
     firstElementChild: {
       /** @this {ParentNode} */
@@ -289,20 +294,16 @@ export const addNativePrefixedProperties = () => {
     copyProperties(Element.prototype, [
       'previousElementSibling',
       'nextElementSibling',
-      'innerHTML'
+      'innerHTML',
+      'className'
     ]);
 
-    // NOTE, on IE 11 / Edge 15 children and/or innerHTML are on HTMLElement instead of Element
-    if (Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'children')) {
-      copyProperties(HTMLElement.prototype, [
-        'children'
-      ]);
-    }
-    if (Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'innerHTML')) {
-      copyProperties(HTMLElement.prototype, [
-        'innerHTML'
-      ]);
-    }
+    // NOTE, on some browsers IE 11 / Edge 15 some properties are incorrectly on HTMLElement
+    copyProperties(HTMLElement.prototype, [
+      'children',
+      'innerHTML',
+      'className'
+    ]);
   } else {
     defineNativeAccessors(Element.prototype, ParentNodeWalkerDescriptors);
     defineNativeAccessors(Element.prototype, {
@@ -347,6 +348,16 @@ export const addNativePrefixedProperties = () => {
             content[NATIVE_PREFIX + 'insertBefore'](firstChild, undefined);
           }
         }
+      },
+      className: {
+        /** @this {Element} */
+        get() {
+          return this.getAttribute('class') || '';
+        },
+        /** @this {Element} */
+        set(value) {
+          this.setAttribute('class', value);
+        }
       }
     });
   }
@@ -365,18 +376,8 @@ export const addNativePrefixedProperties = () => {
   // HTMLElement
   copyProperties(HTMLElement.prototype, [
     'focus',
-    'blur',
-    // On IE these are on HTMLElement
-    'contains'
+    'blur'
   ]);
-
-  if (hasDescriptors) {
-    copyProperties(HTMLElement.prototype, [
-      'parentElement',
-      'children',
-      'innerHTML'
-    ]);
-  }
 
   // HTMLTemplateElement
   if (window.HTMLTemplateElement) {

--- a/src/patches/Document.js
+++ b/src/patches/Document.js
@@ -32,9 +32,8 @@ export const DocumentPatches = utils.getOwnPropertyDescriptors({
     }
     let n = this[utils.NATIVE_PREFIX + 'importNode'](node, false);
     if (deep) {
-      let c$ = node[utils.SHADY_PREFIX + 'childNodes'];
-      for (let i=0, nc; i < c$.length; i++) {
-        nc = this[utils.SHADY_PREFIX + 'importNode'](c$[i], true);
+      for (let c=node[utils.SHADY_PREFIX + 'firstChild'], nc; c; c = c[utils.SHADY_PREFIX + 'nextSibling']) {
+        nc = this[utils.SHADY_PREFIX + 'importNode'](c, true);
         n[utils.SHADY_PREFIX + 'appendChild'](nc);
       }
     }

--- a/src/patches/ElementOrShadowRoot.js
+++ b/src/patches/ElementOrShadowRoot.js
@@ -22,7 +22,7 @@ export const ElementOrShadowRootPatches = utils.getOwnPropertyDescriptors({
     if (utils.isTrackingLogicalChildNodes(this)) {
       const content = this.localName === 'template' ?
       /** @type {HTMLTemplateElement} */(this).content : this;
-      return getInnerHTML(content, (e) => e[utils.SHADY_PREFIX + 'childNodes']);
+      return getInnerHTML(content, utils.childNodesArray);
     } else {
       return this[utils.NATIVE_PREFIX + 'innerHTML'];
     }

--- a/src/patches/HTMLElement.js
+++ b/src/patches/HTMLElement.js
@@ -34,6 +34,9 @@ eventPropertyNames.forEach(property => {
     set: function(fn) {
       const shadyData = ensureShadyDataForNode(this);
       const eventName = property.substring(2);
+      if (!shadyData.__onCallbackListeners) {
+        shadyData.__onCallbackListeners = {};
+      }
       shadyData.__onCallbackListeners[property] && this.removeEventListener(eventName, shadyData.__onCallbackListeners[property]);
       this[utils.SHADY_PREFIX + 'addEventListener'](eventName, fn);
       shadyData.__onCallbackListeners[property] = fn;
@@ -41,7 +44,7 @@ eventPropertyNames.forEach(property => {
     /** @this {HTMLElement} */
     get() {
       const shadyData = shadyDataForNode(this);
-      return shadyData && shadyData.__onCallbackListeners[property];
+      return shadyData && shadyData.__onCallbackListeners && shadyData.__onCallbackListeners[property];
     },
     configurable: true
   };

--- a/src/patches/Node.js
+++ b/src/patches/Node.js
@@ -306,7 +306,7 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
       });
     }
     // if a slot is added, must render containing root.
-    if (this.localName === 'slot' || slotsAdded.length) {
+    if (slotsAdded.length) {
       if (slotsAdded.length) {
         ownerRoot._addSlots(slotsAdded);
       }

--- a/src/patches/Node.js
+++ b/src/patches/Node.js
@@ -36,8 +36,7 @@ export function clearNode(node) {
 function removeOwnerShadyRoot(node) {
   // optimization: only reset the tree if node is actually in a root
   if (hasCachedOwnerRoot(node)) {
-    let c$ = node[utils.SHADY_PREFIX + 'childNodes'];
-    for (let i=0, l=c$.length, n; (i<l) && (n=c$[i]); i++) {
+    for (let n=node[utils.SHADY_PREFIX + 'firstChild']; n; n = n[utils.SHADY_PREFIX + 'nextSibling']) {
       removeOwnerShadyRoot(n);
     }
   }
@@ -187,9 +186,9 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
   get textContent() {
     if (utils.isTrackingLogicalChildNodes(this)) {
       let tc = [];
-      for (let i = 0, cn = this[utils.SHADY_PREFIX + 'childNodes'], c; (c = cn[i]); i++) {
-        if (c.nodeType !== Node.COMMENT_NODE) {
-          tc.push(c[utils.SHADY_PREFIX + 'textContent']);
+      for (let n=this[utils.SHADY_PREFIX + 'firstChild']; n; n = n[utils.SHADY_PREFIX + 'nextSibling']) {
+        if (n.nodeType !== Node.COMMENT_NODE) {
+          tc.push(n[utils.SHADY_PREFIX + 'textContent']);
         }
       }
       return tc.join('');
@@ -448,9 +447,8 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
       // been removed from the spec.
       // Make sure we do not do a deep clone on them for old browsers (IE11)
       if (deep && n.nodeType !== Node.ATTRIBUTE_NODE) {
-        let c$ = this[utils.SHADY_PREFIX + 'childNodes'];
-        for (let i=0, nc; i < c$.length; i++) {
-          nc = c$[i][utils.SHADY_PREFIX + 'cloneNode'](true);
+        for (let c=this[utils.SHADY_PREFIX + 'firstChild'], nc; c; c = c[utils.SHADY_PREFIX + 'nextSibling']) {
+          nc = c[utils.SHADY_PREFIX + 'cloneNode'](true);
           n[utils.SHADY_PREFIX + 'appendChild'](nc);
         }
       }

--- a/src/patches/Node.js
+++ b/src/patches/Node.js
@@ -12,7 +12,7 @@ import * as utils from '../utils.js';
 import {getScopingShim, removeShadyScoping, replaceShadyScoping,
   treeVisitor, currentScopeForNode, currentScopeIsCorrect } from '../style-scoping.js';
 import {shadyDataForNode, ensureShadyDataForNode} from '../shady-data.js';
-import {recordInsertBefore, recordRemoveChild, recordChildNodes} from '../link-nodes.js';
+import {recordInsertBefore, recordRemoveChild} from '../link-nodes.js';
 import {ownerShadyRootForNode} from '../attach-shadow.js';
 
 const doc = window.document;

--- a/src/patches/Node.js
+++ b/src/patches/Node.js
@@ -273,13 +273,13 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     const parentNode = node[utils.SHADY_PREFIX + 'parentNode'];
     if (parentNode) {
       oldScopeName = currentScopeForNode(node);
-      const skipUnscoping = 
-        // Don't remove scoping if we're inserting into another shadowRoot; 
+      const skipUnscoping =
+        // Don't remove scoping if we're inserting into another shadowRoot;
         // this would be unnecessary since it will be re-scoped below
-        Boolean(ownerRoot) || 
+        Boolean(ownerRoot) ||
         // Don't remove scoping if we're being moved between non-shadowRoot
         // locations (the likely case is when moving pre-scoped nodes in a template)
-        !ownerShadyRootForNode(node) || 
+        !ownerShadyRootForNode(node) ||
         // Under preferPerformance, don't remove scoping when moving back into
         // a document fragment that was previously scoped; the assumption is
         // that the user should only move correctly-scoped DOM back into it
@@ -288,10 +288,10 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     }
     // add to new parent
     let allowNativeInsert = true;
-    const needsScoping = (!preferPerformance || 
+    const needsScoping = (!preferPerformance ||
         // Under preferPerformance, only re-scope if we're not coming from a
         // pre-scoped doc fragment or back into a pre-scoped doc fragment
-        (node['__noInsertionPoint'] === undefined && 
+        (node['__noInsertionPoint'] === undefined &&
          this['__noInsertionPoint'] === undefined)) &&
         !currentScopeIsCorrect(node, newScopeName);
     const needsSlotFinding = ownerRoot && !node['__noInsertionPoint'] &&
@@ -372,6 +372,8 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
       // Note: qsa is native when used with noPatch.
       /** @type {?NodeList<Element>} */
       const slotsAdded = this['__noInsertionPoint'] ? null : this.querySelectorAll('slot');
+      // Reset scoping information so normal scoing rules apply after this.
+      this['__noInsertionPoint'] = undefined;
       // if a slot is added, must render containing root.
       if (slotsAdded) {
         this._addSlots(slotsAdded);
@@ -414,7 +416,8 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     }
     // unscope a node leaving a ShadowRoot if ShadyCSS is present, and this node
     // is not going to be rescoped in `insertBefore`
-    if (getScopingShim() && !skipUnscoping && ownerRoot) {
+    if (getScopingShim() && !skipUnscoping && ownerRoot
+      && node.nodeType !== Node.TEXT_NODE) {
       const oldScopeName = currentScopeForNode(node);
       treeVisitor(node, (node) => {
         removeShadyScoping(node, oldScopeName);

--- a/src/patches/Node.js
+++ b/src/patches/Node.js
@@ -365,24 +365,9 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
    * @param {Node} node
    */
   appendChild(node) {
-    // Optimized initial insertion for DOM into a shadowRoot (i.e. into itself).
-    if (this === node && utils.isShadyRoot(node)) {
-      this._setup();
-      recordChildNodes(this, this);
-      // Note: qsa is native when used with noPatch.
-      /** @type {?NodeList<Element>} */
-      const slotsAdded = this['__noInsertionPoint'] ? null : this.querySelectorAll('slot');
-      // Reset scoping information so normal scoing rules apply after this.
-      this['__noInsertionPoint'] = undefined;
-      // if a slot is added, must render containing root.
-      if (slotsAdded) {
-        this._addSlots(slotsAdded);
-      }
-      if (this._hasInsertionPoint()) {
-          this._asyncRender();
-      }
-      /** @type {ShadowRoot} */(this).host[utils.NATIVE_PREFIX + 'appendChild'](this);
-    } else {
+    // if this is a shadowRoot and the shadowRoot is passed as `node`
+    // then an optimized append has already been performed, so do nothing.
+    if (!(this == node && utils.isShadyRoot(node))) {
       return this[utils.SHADY_PREFIX + 'insertBefore'](node);
     }
   },

--- a/src/patches/Node.js
+++ b/src/patches/Node.js
@@ -307,12 +307,8 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
     }
     // if a slot is added, must render containing root.
     if (slotsAdded.length) {
-      if (slotsAdded.length) {
-        ownerRoot._addSlots(slotsAdded);
-      }
-      if (ownerRoot) {
-        ownerRoot._asyncRender();
-      }
+      ownerRoot._addSlots(slotsAdded);
+      ownerRoot._asyncRender();
     }
     if (utils.isTrackingLogicalChildNodes(this)) {
       recordInsertBefore(node, this, ref_node);

--- a/src/patches/ParentNode.js
+++ b/src/patches/ParentNode.js
@@ -18,15 +18,15 @@ import {shadyDataForNode} from '../shady-data.js';
  */
 export function query(node, matcher, halter) {
   let list = [];
-  queryElements(node[utils.SHADY_PREFIX + 'childNodes'], matcher,
+  queryChildNodes(node, matcher,
     halter, list);
   return list;
 }
 
-function queryElements(elements, matcher, halter, list) {
-  for (let i=0, l=elements.length, c; (i<l) && (c=elements[i]); i++) {
-    if (c.nodeType === Node.ELEMENT_NODE &&
-        queryElement(c, matcher, halter, list)) {
+function queryChildNodes(parent, matcher, halter, list) {
+  for (let n = parent[utils.SHADY_PREFIX + 'firstChild']; n; n = n[utils.SHADY_PREFIX + 'nextSibling']) {
+    if (n.nodeType === Node.ELEMENT_NODE &&
+        queryElement(n, matcher, halter, list)) {
       return true;
     }
   }
@@ -40,7 +40,7 @@ function queryElement(node, matcher, halter, list) {
   if (halter && halter(result)) {
     return result;
   }
-  queryElements(node[utils.SHADY_PREFIX + 'childNodes'], matcher,
+  queryChildNodes(node, matcher,
     halter, list);
 }
 
@@ -81,7 +81,7 @@ export const ParentNodePatches = utils.getOwnPropertyDescriptors({
       return this[utils.NATIVE_PREFIX + 'children'];
     }
     return utils.createPolyfilledHTMLCollection(Array.prototype.filter.call(
-        this[utils.SHADY_PREFIX + 'childNodes'], function(n) {
+        utils.childNodesArray(this), (n) => {
       return (n.nodeType === Node.ELEMENT_NODE);
     }));
   },

--- a/src/patches/ShadowRoot.js
+++ b/src/patches/ShadowRoot.js
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import * as utils from '../utils.js';
-import {recordChildNodes} from '../link-nodes.js';
 
 export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
 
@@ -43,26 +42,6 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
     }
     optionsOrCapture.__shadyTarget = this;
     this.host[utils.SHADY_PREFIX + 'removeEventListener'](type, fn, optionsOrCapture);
-  },
-
-  /**
-   * Optimized initial insertion for pre-scoped node.
-   * @param {DocumentFragment} fragment
-   */
-  _attachToHost(host, options) {
-    this._init(host, options);
-    recordChildNodes(this, this);
-    // Note: qsa is native when used with noPatch.
-    /** @type {?NodeList<Element>} */
-    const slotsAdded = this['__noInsertionPoint'] ? null : this.querySelectorAll('slot');
-    // if a slot is added, must render containing root.
-    if (slotsAdded) {
-      this._addSlots(slotsAdded);
-    }
-    if (this._hasInsertionPoint()) {
-        this._asyncRender();
-    }
-    /** @type {ShadowRoot} */(this).host[utils.NATIVE_PREFIX + 'appendChild'](this);
-  },
+  }
 
 });

--- a/src/patches/ShadowRoot.js
+++ b/src/patches/ShadowRoot.js
@@ -45,12 +45,15 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
     this.host[utils.SHADY_PREFIX + 'removeEventListener'](type, fn, optionsOrCapture);
   },
 
-  // Optimized initial insertion for pre-scoped node.
-  ['_attachDom'](node) {
-    recordChildNodes(node, this);
+  /**
+   * Optimized initial insertion for pre-scoped node.
+   * @param {DocumentFragment} fragment
+   */
+  ['_attachDom'](fragment) {
+    recordChildNodes(fragment, this);
     // Note: qsa is native when used with noPatch.
     /** @type {!Array<!HTMLSlotElement>} */
-    const slotsAdded = node['__noInsertionPoint'] ? undefined : node.querySelectorAll('slot');
+    const slotsAdded = fragment['__noInsertionPoint'] ? undefined : fragment.querySelectorAll('slot');
     // if a slot is added, must render containing root.
     if (slotsAdded) {
       this._addSlots(slotsAdded);
@@ -58,8 +61,8 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
     if (this._hasInsertionPoint()) {
         this._asyncRender();
     }
-    /** @type {ShadowRoot} */(this).host[utils.NATIVE_PREFIX + 'appendChild'](node);
-    return node;
+    /** @type {ShadowRoot} */(this).host[utils.NATIVE_PREFIX + 'appendChild'](fragment);
+    return fragment;
   },
 
 });

--- a/src/patches/ShadowRoot.js
+++ b/src/patches/ShadowRoot.js
@@ -52,7 +52,7 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
   _attachDom(fragment) {
     recordChildNodes(fragment, this);
     // Note: qsa is native when used with noPatch.
-    /** @type {?NodeList<(Element|null)>} */
+    /** @type {?NodeList<Element>} */
     const slotsAdded = fragment['__noInsertionPoint'] ? null : fragment.querySelectorAll('slot');
     // if a slot is added, must render containing root.
     if (slotsAdded) {

--- a/src/patches/ShadowRoot.js
+++ b/src/patches/ShadowRoot.js
@@ -49,11 +49,11 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
    * Optimized initial insertion for pre-scoped node.
    * @param {DocumentFragment} fragment
    */
-  ['_attachDom'](fragment) {
+  _attachDom(fragment) {
     recordChildNodes(fragment, this);
     // Note: qsa is native when used with noPatch.
-    /** @type {!Array<!HTMLSlotElement>} */
-    const slotsAdded = fragment['__noInsertionPoint'] ? undefined : fragment.querySelectorAll('slot');
+    /** @type {?NodeList<(Element|null)>} */
+    const slotsAdded = fragment['__noInsertionPoint'] ? null : fragment.querySelectorAll('slot');
     // if a slot is added, must render containing root.
     if (slotsAdded) {
       this._addSlots(slotsAdded);

--- a/src/patches/ShadowRoot.js
+++ b/src/patches/ShadowRoot.js
@@ -49,11 +49,12 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
    * Optimized initial insertion for pre-scoped node.
    * @param {DocumentFragment} fragment
    */
-  _attachDom(fragment) {
-    recordChildNodes(fragment, this);
+  _attachToHost(host, options) {
+    this._init(host, options);
+    recordChildNodes(this, this);
     // Note: qsa is native when used with noPatch.
     /** @type {?NodeList<Element>} */
-    const slotsAdded = fragment['__noInsertionPoint'] ? null : fragment.querySelectorAll('slot');
+    const slotsAdded = this['__noInsertionPoint'] ? null : this.querySelectorAll('slot');
     // if a slot is added, must render containing root.
     if (slotsAdded) {
       this._addSlots(slotsAdded);
@@ -61,8 +62,7 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
     if (this._hasInsertionPoint()) {
         this._asyncRender();
     }
-    /** @type {ShadowRoot} */(this).host[utils.NATIVE_PREFIX + 'appendChild'](fragment);
-    return fragment;
+    /** @type {ShadowRoot} */(this).host[utils.NATIVE_PREFIX + 'appendChild'](this);
   },
 
 });

--- a/src/shady-data.js
+++ b/src/shady-data.js
@@ -10,40 +10,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 
 export class ShadyData {
-  constructor() {
-    /** @type {ShadowRoot} */
-    this.root = null;
-    /** @type {ShadowRoot} */
-    this.publicRoot = null;
-    this.dirty = false;
-    this.observer = null;
-    /** @type {Array<Node>} */
-    this.assignedNodes = null;
-    /** @type {Element} */
-    this.assignedSlot = null;
-    /** @type {Array<Node>} */
-    this._previouslyAssignedNodes = null;
-    /** @type {Element} */
-    this._prevAssignedSlot = null;
-    /** @type {Array<Node>} */
-    this.flattenedNodes = null;
-    this.ownerShadyRoot = undefined;
-    /** @type {Node|undefined} */
-    this.parentNode = undefined;
-    /** @type {Node|undefined} */
-    this.firstChild = undefined;
-    /** @type {Node|undefined} */
-    this.lastChild = undefined;
-    /** @type {Node|undefined} */
-    this.previousSibling = undefined;
-    /** @type {Node|undefined} */
-    this.nextSibling = undefined;
-    /** @type {Array<Node>|undefined} */
-    this.childNodes = undefined;
-    this.__outsideAccessors = false;
-    this.__insideAccessors = false;
-    this.__onCallbackListeners = {};
-  }
 
   /** @override */
   toJSON() {

--- a/src/shadydom.js
+++ b/src/shadydom.js
@@ -84,10 +84,17 @@ if (utils.settings.inUse) {
     'nativeMethods': nativeMethods,
     'nativeTree': nativeTree,
     'upgrade': (fragment, host, options) => {
-      fragment.__proto__ = ShadowRoot.prototype;
-      fragment._init(fragment, host, options);
-      fragment._attachDom(fragment);
-      return fragment;
+      let root;
+      if (!window.customElements || !window.customElements.polyfillWrapFlushCallback) {
+        fragment.__proto__ = ShadowRoot.prototype;
+        fragment._init(fragment, host, options);
+        fragment._attachDom(fragment);
+        root = fragment;
+      } else {
+        root = ShadyDOM.wrap(host).attachShadow(options);
+        root.appendChild(fragment);
+      }
+      return root;
     }
   };
 

--- a/src/shadydom.js
+++ b/src/shadydom.js
@@ -82,7 +82,13 @@ if (utils.settings.inUse) {
     // access that requires Shadow DOM behavior to be proxied via `ShadyDOM.wrap`.
     'noPatch': utils.settings.noPatch,
     'nativeMethods': nativeMethods,
-    'nativeTree': nativeTree
+    'nativeTree': nativeTree,
+    'upgrade': (fragment, host, options) => {
+      fragment.__proto__ = ShadowRoot.prototype;
+      fragment._init(fragment, host, options);
+      fragment._attachDom(fragment);
+      return fragment;
+    }
   };
 
   window['ShadyDOM'] = ShadyDOM;

--- a/src/shadydom.js
+++ b/src/shadydom.js
@@ -85,7 +85,7 @@ if (utils.settings.inUse) {
     'noPatch': utils.settings.noPatch,
     'nativeMethods': nativeMethods,
     'nativeTree': nativeTree,
-    'upgrade': (fragment, host, options) => {
+    'attachDom': (fragment, host, options) => {
       let root;
       if (utils.canUpgrade()) {
         fragment.__proto__ = ShadowRoot.prototype;

--- a/src/shadydom.js
+++ b/src/shadydom.js
@@ -89,8 +89,7 @@ if (utils.settings.inUse) {
       let root;
       if (utils.canUpgrade()) {
         fragment.__proto__ = ShadowRoot.prototype;
-        fragment._init(fragment, host, options);
-        fragment._attachDom(fragment);
+        fragment._attachToHost(host, options);
         root = fragment;
       } else {
         root = ShadyDOM['wrap'](host).attachShadow(options);

--- a/src/shadydom.js
+++ b/src/shadydom.js
@@ -88,17 +88,13 @@ if (utils.settings.inUse) {
     'attachDom': (fragment, host, options) => {
       let root;
       if (utils.canUpgrade()) {
-        fragment.__proto__ = ShadowRoot.prototype;
-        fragment._attachToHost(host, options);
-        root = fragment;
-      } else {
-        root = ShadyDOM['wrap'](host).attachShadow(options);
-        root.appendChild(fragment);
+        host.__shady_fragment = fragment;
       }
+      root = ShadyDOM['wrap'](host).attachShadow(options);
+      root.appendChild(fragment);
       return root;
     }
   };
-
 
   window['ShadyDOM'] = ShadyDOM;
 

--- a/src/shadydom.js
+++ b/src/shadydom.js
@@ -84,16 +84,7 @@ if (utils.settings.inUse) {
     // access that requires Shadow DOM behavior to be proxied via `ShadyDOM.wrap`.
     'noPatch': utils.settings.noPatch,
     'nativeMethods': nativeMethods,
-    'nativeTree': nativeTree,
-    'attachDom': (fragment, host, options) => {
-      let root;
-      if (utils.canUpgrade()) {
-        host.__shady_fragment = fragment;
-      }
-      root = ShadyDOM['wrap'](host).attachShadow(options);
-      root.appendChild(fragment);
-      return root;
-    }
+    'nativeTree': nativeTree
   };
 
   window['ShadyDOM'] = ShadyDOM;

--- a/src/shadydom.js
+++ b/src/shadydom.js
@@ -28,7 +28,9 @@ import {ShadyRoot} from './attach-shadow.js';
 import {wrap, Wrapper} from './wrapper.js';
 import {addShadyPrefixedProperties, applyPatches} from './patch-prototypes.js';
 
+
 if (utils.settings.inUse) {
+
   let ShadyDOM = {
     // TODO(sorvell): remove when Polymer does not depend on this.
     'inUse': utils.settings.inUse,
@@ -85,18 +87,19 @@ if (utils.settings.inUse) {
     'nativeTree': nativeTree,
     'upgrade': (fragment, host, options) => {
       let root;
-      if (!window.customElements || !window.customElements.polyfillWrapFlushCallback) {
+      if (utils.canUpgrade()) {
         fragment.__proto__ = ShadowRoot.prototype;
         fragment._init(fragment, host, options);
         fragment._attachDom(fragment);
         root = fragment;
       } else {
-        root = ShadyDOM.wrap(host).attachShadow(options);
+        root = ShadyDOM['wrap'](host).attachShadow(options);
         root.appendChild(fragment);
       }
       return root;
     }
   };
+
 
   window['ShadyDOM'] = ShadyDOM;
 

--- a/src/style-scoping.js
+++ b/src/style-scoping.js
@@ -87,10 +87,9 @@ export function currentScopeIsCorrect(node, newScopeName) {
     // NOTE: as an optimization, only check that all the top-level children
     // have the correct scope.
     let correctScope = true;
-    const childNodes = node[utils.SHADY_PREFIX + 'childNodes'];
-    for (let idx = 0; correctScope && (idx < childNodes.length); idx++) {
+    for (let n=node[utils.SHADY_PREFIX + 'firstChild']; n; n = n[utils.SHADY_PREFIX + 'nextSibling']) {
       correctScope = correctScope &&
-        currentScopeIsCorrect(childNodes[idx], newScopeName);
+        currentScopeIsCorrect(n, newScopeName);
     }
     return correctScope;
   }
@@ -130,9 +129,7 @@ export function treeVisitor(node, visitorFn) {
   if (node.nodeType === Node.ELEMENT_NODE) {
     visitorFn(node);
   }
-  const childNodes = node[utils.SHADY_PREFIX + 'childNodes'];
-  for (let idx = 0, n; idx < childNodes.length; idx++) {
-    n = childNodes[idx];
+  for (let n = node[utils.SHADY_PREFIX + 'firstChild']; n; (n = n[utils.SHADY_PREFIX + 'nextSibling'])) {
     if (n.nodeType === Node.ELEMENT_NODE) {
       treeVisitor(n, visitorFn);
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -21,6 +21,19 @@ settings.inUse = settings['force'] || !settings.hasNativeShadowDOM;
 settings.noPatch = settings['noPatch'] || false;
 settings.preferPerformance = settings['preferPerformance'];
 
+const IS_IE = navigator.userAgent.match('Trident');
+settings.IS_IE = IS_IE;
+
+let _canUpgrade;
+// do not use `upgrade` when custom elements is polyfilled or on IE.
+export const canUpgrade = () => {
+  if (_canUpgrade === undefined) {
+    _canUpgrade = (window['customElements'] && !window['customElements']['polyfillWrapFlushCallback']) &&
+      !settings.IS_IE;
+  }
+  return _canUpgrade;
+}
+
 export const isTrackingLogicalChildNodes = (node) => {
   const nodeData = shadyDataForNode(node);
   return (nodeData && nodeData.firstChild !== undefined);

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,7 +127,21 @@ export const createPolyfilledHTMLCollection = (nodes) => {
 export const NATIVE_PREFIX = '__shady_native_';
 export const SHADY_PREFIX = '__shady_';
 
+export const nativeChildNodesArray = (parent) => {
+  const result = [];
+  for (let n=parent[NATIVE_PREFIX + 'firstChild']; n; n = n[NATIVE_PREFIX + 'nextSibling']) {
+    result.push(n);
+  }
+  return result;
+}
 
+export const childNodesArray = (parent) => {
+  const result = [];
+  for (let n=parent[SHADY_PREFIX + 'firstChild']; n; n = n[SHADY_PREFIX + 'nextSibling']) {
+    result.push(n);
+  }
+  return result;
+}
 
 /**
  * Patch a group of accessors on an object only if it exists or if the `force`

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,15 +24,7 @@ settings.preferPerformance = settings['preferPerformance'];
 const IS_IE = navigator.userAgent.match('Trident');
 settings.IS_IE = IS_IE;
 
-let _canUpgrade;
-// do not use `upgrade` when custom elements is polyfilled or on IE.
-export const canUpgrade = () => {
-  if (_canUpgrade === undefined) {
-    _canUpgrade = (window['customElements'] && !window['customElements']['polyfillWrapFlushCallback']) &&
-      !settings.IS_IE;
-  }
-  return _canUpgrade;
-}
+export const canUpgrade = () => !settings.IS_IE;
 
 export const isTrackingLogicalChildNodes = (node) => {
   const nodeData = shadyDataForNode(node);

--- a/tests/shady-dynamic.html
+++ b/tests/shady-dynamic.html
@@ -710,6 +710,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     assert.notOk(projected);
   });
 
+  test('disconnected node: isConnected, getRootNode', function() {
+    let div = document.createElement('div');
+    assert.isFalse(ShadyDOM.wrap(div).isConnected);
+    assert.equal(ShadyDOM.wrap(div).getRootNode(), div);
+  });
+
+  test('slot, assignedSlot accessor', function() {
+    let div = document.createElement('div');
+    ShadyDOM.wrap(div).slot = 'slot';
+    assert.equal(ShadyDOM.wrap(div).slot, 'slot');
+    assert.equal(div.getAttribute('slot'), 'slot');
+    assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
+  });
+
   test('parentNode', function() {
     var rere = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('x-rereproject');
     var projected = ShadyDOM.wrap(ShadyDOM.wrap(testElement).shadowRoot).querySelector('#projected');

--- a/tests/shady.html
+++ b/tests/shady.html
@@ -69,7 +69,7 @@ suite('Rendering', function() {
       ShadyDOM.wrap(document.body).removeChild(host);
     });
 
-    test(descr + ' fragment via ShadyDOM.attachDom', function() {
+    test(descr + ' fragment via options: shadyUpgradeFragment', function() {
       // Create an instance of the test element.
       var host = document.createElement('div');
       // Populate the initial pool of light DOM children.
@@ -82,7 +82,8 @@ suite('Rendering', function() {
       while (ShadyDOM.wrap(div).firstChild) {
         ShadyDOM.wrap(frag).appendChild(ShadyDOM.wrap(div).firstChild);
       }
-      ShadyDOM.attachDom(frag, host, {mode: 'open'});
+      ShadyDOM.wrap(host).attachShadow({mode: 'open', shadyUpgradeFragment: frag});
+      ShadyDOM.wrap(host).appendChild(frag);
       // Invoke distribution and verify the resulting tree.
       ShadyDOM.flush();
       assert.strictEqual(getComposedHTML(host), expectedHtml);

--- a/tests/shady.html
+++ b/tests/shady.html
@@ -68,7 +68,7 @@ suite('Rendering', function() {
       ShadyDOM.wrap(document.body).removeChild(host);
     });
 
-    test(descr + ' fragment via ShadyDOM.upgrade', function() {
+    test(descr + ' fragment via ShadyDOM.attachDom', function() {
       // Create an instance of the test element.
       var host = document.createElement('div');
       // Populate the initial pool of light DOM children.
@@ -81,7 +81,7 @@ suite('Rendering', function() {
       while (ShadyDOM.wrap(div).firstChild) {
         ShadyDOM.wrap(frag).appendChild(ShadyDOM.wrap(div).firstChild);
       }
-      ShadyDOM.upgrade(frag, host, {mode: 'open'});
+      ShadyDOM.attachDom(frag, host, {mode: 'open'});
       // Invoke distribution and verify the resulting tree.
       ShadyDOM.flush();
       assert.strictEqual(getComposedHTML(host), expectedHtml);

--- a/tests/shady.html
+++ b/tests/shady.html
@@ -83,7 +83,7 @@ suite('Rendering', function() {
         ShadyDOM.wrap(frag).appendChild(ShadyDOM.wrap(div).firstChild);
       }
       ShadyDOM.wrap(host).attachShadow({mode: 'open', shadyUpgradeFragment: frag});
-      ShadyDOM.wrap(host).appendChild(frag);
+      ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).appendChild(frag);
       // Invoke distribution and verify the resulting tree.
       ShadyDOM.flush();
       assert.strictEqual(getComposedHTML(host), expectedHtml);

--- a/tests/shady.html
+++ b/tests/shady.html
@@ -23,73 +23,85 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
 <script>
 
-/**
- * Test the `<slot>` element distribution algorithm by verifying the
- * resulting composed tree structure.
- */
-function testRender(descr, hostInnerHtml, shadowRootHtml, expectedHtml) {
-  test(descr, function() {
-    // Create an instance of the test element.
-    var host = document.createElement('div');
-    ShadyDOM.wrap(host).attachShadow({mode: 'open'});
-    // Populate the initial pool of light DOM children.
-    ShadyDOM.wrap(host).innerHTML = hostInnerHtml;
-    ShadyDOM.wrap(document.body).appendChild(host);
-        // Pretend we're stamping the template contents.
-    if (shadowRootHtml) {
-      ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = shadowRootHtml;
-    }
-    // Invoke distribution and verify the resulting tree.
-    ShadyDOM.flush();
-    assert.strictEqual(getComposedHTML(host), expectedHtml);
-    ShadyDOM.wrap(document.body).removeChild(host);
-  });
-  test(descr + ' fragment', function() {
-    // Create an instance of the test element.
-    var host = document.createElement('div');
-    ShadyDOM.wrap(host).attachShadow({mode: 'open'});
-    // Populate the initial pool of light DOM children.
-    ShadyDOM.wrap(host).innerHTML = hostInnerHtml;
-    ShadyDOM.wrap(document.body).appendChild(host);
-        // Pretend we're stamping the template contents.
-    var div = document.createElement('div');
-    ShadyDOM.wrap(div).innerHTML = shadowRootHtml;
-    var frag = document.createDocumentFragment();
-    while (ShadyDOM.wrap(div).firstChild) {
-      ShadyDOM.wrap(frag).appendChild(ShadyDOM.wrap(div).firstChild);
-    }
-    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).appendChild(frag);
-    // Invoke distribution and verify the resulting tree.
-    ShadyDOM.flush();
-    assert.strictEqual(getComposedHTML(host), expectedHtml);
-    ShadyDOM.wrap(document.body).removeChild(host);
-  });
-}
 
-test('Node/Element accessors', function() {
-  var div = document.createElement('div');
-  assert.isFalse(ShadyDOM.wrap(div).isConnected);
-  assert.equal(ShadyDOM.wrap(div).getRootNode(), div);
-  ShadyDOM.wrap(div).slot = 'slot';
-  assert.equal(ShadyDOM.wrap(div).slot, 'slot');
-  assert.equal(div.getAttribute('slot'), 'slot');
-  assert.equal(ShadyDOM.wrap(div).assignedSlot, null);
-});
+suite('Rendering', function() {
 
-testRender('Empty shadow', 'abc', '', '');
-testRender('Simple shadow', 'abc', 'def', 'def');
-testRender('Fallback shadow', 'abc',
-           '<slot name="xxx">fallback</name>', 'fallback');
-testRender('Fallback shadow, empty host', '',
-           '<slot name="xxx">fallback</name>', 'fallback');
-testRender('Content', 'abc',
-           '<slot>fallback</slot>', 'abc');
-testRender('Content before', 'abc',
-           'before<slot>fallback</slot>', 'beforeabc');
-testRender('Content after', 'abc',
-           '<slot>fallback</slot>after', 'abcafter');
+  /**
+   * Test the `<slot>` element distribution algorithm by verifying the
+   * resulting composed tree structure.
+   */
+  function testRender(descr, hostInnerHtml, shadowRootHtml, expectedHtml) {
+    test(descr, function() {
+      // Create an instance of the test element.
+      var host = document.createElement('div');
+      ShadyDOM.wrap(host).attachShadow({mode: 'open'});
+      // Populate the initial pool of light DOM children.
+      ShadyDOM.wrap(host).innerHTML = hostInnerHtml;
+      ShadyDOM.wrap(document.body).appendChild(host);
+          // Pretend we're stamping the template contents.
+      if (shadowRootHtml) {
+        ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = shadowRootHtml;
+      }
+      // Invoke distribution and verify the resulting tree.
+      ShadyDOM.flush();
+      assert.strictEqual(getComposedHTML(host), expectedHtml);
+      ShadyDOM.wrap(document.body).removeChild(host);
+    });
+    test(descr + ' fragment', function() {
+      // Create an instance of the test element.
+      var host = document.createElement('div');
+      ShadyDOM.wrap(host).attachShadow({mode: 'open'});
+      // Populate the initial pool of light DOM children.
+      ShadyDOM.wrap(host).innerHTML = hostInnerHtml;
+      ShadyDOM.wrap(document.body).appendChild(host);
+          // Pretend we're stamping the template contents.
+      var div = document.createElement('div');
+      ShadyDOM.wrap(div).innerHTML = shadowRootHtml;
+      var frag = document.createDocumentFragment();
+      while (ShadyDOM.wrap(div).firstChild) {
+        ShadyDOM.wrap(frag).appendChild(ShadyDOM.wrap(div).firstChild);
+      }
+      ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).appendChild(frag);
+      // Invoke distribution and verify the resulting tree.
+      ShadyDOM.flush();
+      assert.strictEqual(getComposedHTML(host), expectedHtml);
+      ShadyDOM.wrap(document.body).removeChild(host);
+    });
 
-suite('render content', function() {
+    test(descr + ' fragment via ShadyDOM.upgrade', function() {
+      // Create an instance of the test element.
+      var host = document.createElement('div');
+      // Populate the initial pool of light DOM children.
+      ShadyDOM.wrap(host).innerHTML = hostInnerHtml;
+      ShadyDOM.wrap(document.body).appendChild(host);
+          // Pretend we're stamping the template contents.
+      var div = document.createElement('div');
+      ShadyDOM.wrap(div).innerHTML = shadowRootHtml;
+      var frag = document.createDocumentFragment();
+      while (ShadyDOM.wrap(div).firstChild) {
+        ShadyDOM.wrap(frag).appendChild(ShadyDOM.wrap(div).firstChild);
+      }
+      ShadyDOM.upgrade(frag, host, {mode: 'open'});
+      // Invoke distribution and verify the resulting tree.
+      ShadyDOM.flush();
+      assert.strictEqual(getComposedHTML(host), expectedHtml);
+      ShadyDOM.wrap(document.body).removeChild(host);
+    });
+  }
+
+  testRender('Empty shadow', 'abc', '', '');
+  testRender('Simple shadow', 'abc', 'def', 'def');
+  testRender('Fallback shadow', 'abc',
+            '<slot name="xxx">fallback</name>', 'fallback');
+  testRender('Fallback shadow, empty host', '',
+            '<slot name="xxx">fallback</name>', 'fallback');
+  testRender('Content', 'abc',
+            '<slot>fallback</slot>', 'abc');
+  testRender('Content before', 'abc',
+            'before<slot>fallback</slot>', 'beforeabc');
+  testRender('Content after', 'abc',
+            '<slot>fallback</slot>after', 'abcafter');
+
   testRender('no select', '<a href="">Link</a> <b>bold</b>',
              '<slot></slot>',
              '<a href="">Link</a> <b>bold</b>');
@@ -121,50 +133,54 @@ suite('render content', function() {
              '<span>a</span><span>b</span><span slot="c">c</span><span>d</span>',
              '<slot name="c"></slot><slot></slot>',
              '<span slot="c">c</span><span>a</span><span>b</span><span>d</span>');
+
 });
 
+suite('Reprojection', function() {
 
-test('Reproject', function() {
-  var host = document.createElement('div');
-  ShadyDOM.wrap(host).attachShadow({mode: 'open'});
-  ShadyDOM.wrap(document.body).appendChild(host);
-    ShadyDOM.wrap(host).innerHTML = '<a></a>';
-  // pre-distirbution grab first composed node.
-  var a = getComposedChildAtIndex(host, 0);
-  ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<div id="p"></div>';
-  ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstElementChild).attachShadow({mode: 'open'});
-  // force upgrade on polyfilled browsers
-  var p = ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild;
-    ShadyDOM.wrap(p).innerHTML = '<b slot="b"></b><slot slot="a"></slot>';
-  var b = ShadyDOM.wrap(p).firstChild;
-  var content = ShadyDOM.wrap(p).lastChild;
+  test('Reprojection', function() {
+    var host = document.createElement('div');
+    ShadyDOM.wrap(host).attachShadow({mode: 'open'});
+    ShadyDOM.wrap(document.body).appendChild(host);
+      ShadyDOM.wrap(host).innerHTML = '<a></a>';
+    // pre-distirbution grab first composed node.
+    var a = getComposedChildAtIndex(host, 0);
+    ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).innerHTML = '<div id="p"></div>';
+    ShadyDOM.wrap(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstElementChild).attachShadow({mode: 'open'});
+    // force upgrade on polyfilled browsers
+    var p = ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).firstChild;
+      ShadyDOM.wrap(p).innerHTML = '<b slot="b"></b><slot slot="a"></slot>';
+    var b = ShadyDOM.wrap(p).firstChild;
+    var content = ShadyDOM.wrap(p).lastChild;
 
-  ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).innerHTML =
-      'a: <slot name="a"></slot>b: <slot name="b"></slot>';
-  var textNodeA = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).firstChild;
-  var contentA = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes[1];
-  var textNodeB = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes[2];
-  var contentB = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes[3];
+    ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).innerHTML =
+        'a: <slot name="a"></slot>b: <slot name="b"></slot>';
+    var textNodeA = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).firstChild;
+    var contentA = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes[1];
+    var textNodeB = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes[2];
+    var contentB = ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes[3];
 
-  function testRender() {
-    ShadyDOM.flush();
-    assert.strictEqual(getComposedHTML(host),
-        '<div id="p">a: <a></a>b: <b slot="b"></b></div>');
+    function testRender() {
+      ShadyDOM.flush();
+      assert.strictEqual(getComposedHTML(host),
+          '<div id="p">a: <a></a>b: <b slot="b"></b></div>');
 
-    assert.deepEqual(Array.from(ShadyDOM.wrap(host).childNodes), [a]);
-    assert.strictEqual(ShadyDOM.wrap(a).parentNode, host);
-    assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).childNodes), [p]);
-    assert.strictEqual(ShadyDOM.wrap(p).parentNode, ShadyDOM.wrap(host).shadowRoot);
-    assert.deepEqual(Array.from(ShadyDOM.wrap(p).childNodes), [b, content]);
-    assert.strictEqual(ShadyDOM.wrap(b).parentNode, p);
-    assert.strictEqual(ShadyDOM.wrap(content).parentNode, p);
-    assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes),
-        [textNodeA, contentA, textNodeB, contentB]);
-  }
+      assert.deepEqual(Array.from(ShadyDOM.wrap(host).childNodes), [a]);
+      assert.strictEqual(ShadyDOM.wrap(a).parentNode, host);
+      assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).childNodes), [p]);
+      assert.strictEqual(ShadyDOM.wrap(p).parentNode, ShadyDOM.wrap(host).shadowRoot);
+      assert.deepEqual(Array.from(ShadyDOM.wrap(p).childNodes), [b, content]);
+      assert.strictEqual(ShadyDOM.wrap(b).parentNode, p);
+      assert.strictEqual(ShadyDOM.wrap(content).parentNode, p);
+      assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(p).shadowRoot).childNodes),
+          [textNodeA, contentA, textNodeB, contentB]);
+    }
 
-  testRender();
-  testRender();
-  ShadyDOM.wrap(document.body).removeChild(host);
+    testRender();
+    testRender();
+    ShadyDOM.wrap(document.body).removeChild(host);
+  });
+
 });
 
 
@@ -696,7 +712,7 @@ suite('Patch of innerHTML setter', function() {
 
 suite('Patch of getElementById', function() {
   [undefined, null, '', 'unknown-elem'].forEach(function(id) {
-    test.only(`should return null for unknown id: "${id}"`, function() {
+    test(`should return null for unknown id: "${id}"`, function() {
       const elem = document.getElementById(id);
       assert.isNull(elem);
     });


### PR DESCRIPTION
This API is being added as an optimization for creating and initially populating a ShadowRoot. Instead of:

```js
element.attachShadow({mode: 'open'});
element.shadowRoot.appendChild(aDocFragment);
```

it's now faster to do:

```js
element.attachShadow({mode: 'open', shadyUpgradeFragment: aDocFragment});
element.shadowRoot.appendChild(aDocFragment);
```

This removes the need to create an extra document fragment and optimizes the copying of nodes into the `shadowRoot`. Note that when this is used, the passed in `documentFragment` becomes the `shadowRoot`.