### PR TITLE
fix: don't use isConnected polyfill if the native version returns false.

### DIFF
--- a/src/patches/Node.js
+++ b/src/patches/Node.js
@@ -159,8 +159,8 @@ export const NodePatches = utils.getOwnPropertyDescriptors({
 
   /** @this {Node} */
   get isConnected() {
-    if (nativeIsConnected && nativeIsConnected.call(this)) {
-      return true;
+    if (nativeIsConnected) {
+      return nativeIsConnected.call(this);
     }
     if (this.nodeType == Node.DOCUMENT_FRAGMENT_NODE) {
       return false;


### PR DESCRIPTION
If the native version exists, shouldn't we return whichever result it returns?