### PR TITLE
Allow event listeners on <slot> elements

### DIFF
--- a/src/patch-events.js
+++ b/src/patch-events.js
@@ -347,6 +347,10 @@ function getEventWrappers(eventLike) {
   return wrappers;
 }
 
+function targetNeedsPathCheck(node) {
+  return utils.isShadyRoot(node) || node.localName === 'slot';
+}
+
 /**
  * @this {EventTarget}
  */
@@ -421,10 +425,10 @@ export function addEventListener(type, fnOrObj, optionsOrCapture) {
       Object.defineProperty(e, 'currentTarget', {get() { return target }, configurable: true});
     }
     e['__previousCurrentTarget'] = e['currentTarget'];
-    // Always check if a shadowRoot is in the current event path.
+    // Always check if a shadowRoot or slot is in the current event path.
     // If it is not, the event was generated on either the host of the shadowRoot
     // or a children of the host.
-    if (utils.isShadyRoot(target) && e.composedPath().indexOf(target) == -1) {
+    if (targetNeedsPathCheck(target) && e.composedPath().indexOf(target) == -1) {
       return;
     }
     // There are two critera that should stop events from firing on this node

--- a/src/patches/ShadowRoot.js
+++ b/src/patches/ShadowRoot.js
@@ -24,7 +24,8 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
         capture: Boolean(optionsOrCapture)
       }
     }
-    optionsOrCapture.__shadyTarget = this;
+    // Note, `__shadyTarget` may already be set if an event was added on a <slot> child
+    optionsOrCapture.__shadyTarget = optionsOrCapture.__shadyTarget || this;
     this.host[utils.SHADY_PREFIX + 'addEventListener'](type, fn, optionsOrCapture);
   },
 
@@ -40,7 +41,8 @@ export const ShadowRootPatches = utils.getOwnPropertyDescriptors({
         capture: Boolean(optionsOrCapture)
       }
     }
-    optionsOrCapture.__shadyTarget = this;
+    // Note, `__shadyTarget` may already be set if an event was added on a <slot> child
+    optionsOrCapture.__shadyTarget = optionsOrCapture.__shadyTarget || this;
     this.host[utils.SHADY_PREFIX + 'removeEventListener'](type, fn, optionsOrCapture);
   }
 

--- a/src/patches/Slot.js
+++ b/src/patches/Slot.js
@@ -46,7 +46,9 @@ export const SlotPatches = utils.getOwnPropertyDescriptors({
         capture: Boolean(optionsOrCapture)
       }
     }
-    if (type === 'slotchange') {
+    // NOTE, check if this is a `slot` because these patches are installed on
+    // Element where browsers don't have `<slot>`
+    if (this.localName !== 'slot' || type === 'slotchange') {
       addEventListener.call(this, type, fn, optionsOrCapture);
     } else {
       const parent = this[utils.SHADY_PREFIX + 'parentNode'];
@@ -70,7 +72,9 @@ export const SlotPatches = utils.getOwnPropertyDescriptors({
         capture: Boolean(optionsOrCapture)
       }
     }
-    if (type === 'slotchange') {
+    // NOTE, check if this is a `slot` because these patches are installed on
+    // Element where browsers don't have `<slot>`
+    if (this.localName !== 'slot' || type === 'slotchange') {
       removeEventListener.call(this, type, fn, optionsOrCapture);
     } else {
       const parent = this[utils.SHADY_PREFIX + 'parentNode'];

--- a/src/patches/Slot.js
+++ b/src/patches/Slot.js
@@ -41,16 +41,16 @@ export const SlotPatches = utils.getOwnPropertyDescriptors({
    * @param {Object|boolean=} optionsOrCapture
    */
   addEventListener(type, fn, optionsOrCapture) {
-    if (typeof optionsOrCapture !== 'object') {
-      optionsOrCapture = {
-        capture: Boolean(optionsOrCapture)
-      }
-    }
     // NOTE, check if this is a `slot` because these patches are installed on
     // Element where browsers don't have `<slot>`
     if (this.localName !== 'slot' || type === 'slotchange') {
       addEventListener.call(this, type, fn, optionsOrCapture);
     } else {
+      if (typeof optionsOrCapture !== 'object') {
+        optionsOrCapture = {
+          capture: Boolean(optionsOrCapture)
+        }
+      }
       const parent = this[utils.SHADY_PREFIX + 'parentNode'];
       if (!parent) {
         throw new Error('ShadyDOM cannot attach event to slot unless it has a `parentNode`');
@@ -67,16 +67,16 @@ export const SlotPatches = utils.getOwnPropertyDescriptors({
    * @param {Object|boolean=} optionsOrCapture
    */
   removeEventListener(type, fn, optionsOrCapture) {
-    if (typeof optionsOrCapture !== 'object') {
-      optionsOrCapture = {
-        capture: Boolean(optionsOrCapture)
-      }
-    }
     // NOTE, check if this is a `slot` because these patches are installed on
     // Element where browsers don't have `<slot>`
     if (this.localName !== 'slot' || type === 'slotchange') {
       removeEventListener.call(this, type, fn, optionsOrCapture);
     } else {
+      if (typeof optionsOrCapture !== 'object') {
+        optionsOrCapture = {
+          capture: Boolean(optionsOrCapture)
+        }
+      }
       const parent = this[utils.SHADY_PREFIX + 'parentNode'];
       if (!parent) {
         throw new Error('ShadyDOM cannot attach event to slot unless it has a `parentNode`');

--- a/src/patches/Slot.js
+++ b/src/patches/Slot.js
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import * as utils from '../utils.js';
 import {shadyDataForNode} from '../shady-data.js';
+import {addEventListener, removeEventListener} from '../patch-events.js';
 
 export const SlotPatches = utils.getOwnPropertyDescriptors({
 
@@ -30,6 +31,54 @@ export const SlotPatches = utils.getOwnPropertyDescriptors({
         ((options && options.flatten ? nodeData.flattenedNodes :
           nodeData.assignedNodes) || []) :
         [];
+    }
+  },
+
+  /**
+   * @this {HTMLSlotElement}
+   * @param {string} type
+   * @param {Function} fn
+   * @param {Object|boolean=} optionsOrCapture
+   */
+  addEventListener(type, fn, optionsOrCapture) {
+    if (typeof optionsOrCapture !== 'object') {
+      optionsOrCapture = {
+        capture: Boolean(optionsOrCapture)
+      }
+    }
+    if (type === 'slotchange') {
+      addEventListener.call(this, type, fn, optionsOrCapture);
+    } else {
+      const parent = this[utils.SHADY_PREFIX + 'parentNode'];
+      if (!parent) {
+        throw new Error('ShadyDOM cannot attach event to slot unless it has a `parentNode`');
+      }
+      optionsOrCapture.__shadyTarget = this;
+      parent[utils.SHADY_PREFIX + 'addEventListener'](type, fn, optionsOrCapture);
+    }
+  },
+
+  /**
+   * @this {HTMLSlotElement}
+   * @param {string} type
+   * @param {Function} fn
+   * @param {Object|boolean=} optionsOrCapture
+   */
+  removeEventListener(type, fn, optionsOrCapture) {
+    if (typeof optionsOrCapture !== 'object') {
+      optionsOrCapture = {
+        capture: Boolean(optionsOrCapture)
+      }
+    }
+    if (type === 'slotchange') {
+      removeEventListener.call(this, type, fn, optionsOrCapture);
+    } else {
+      const parent = this[utils.SHADY_PREFIX + 'parentNode'];
+      if (!parent) {
+        throw new Error('ShadyDOM cannot attach event to slot unless it has a `parentNode`');
+      }
+      optionsOrCapture.__shadyTarget = this;
+      parent[utils.SHADY_PREFIX + 'removeEventListener'](type, fn, optionsOrCapture);
     }
   }
 

--- a/tests/event-path.html
+++ b/tests/event-path.html
@@ -338,6 +338,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrap(ShadyDOM.wrap(el).parentNode).removeChild(el);
     });
 
+    test('bubbling events reach shadowRoot', function() {
+      // Create a div element with a shadow root
+      const theDiv = document.createElement('div');
+      const root = ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrap(document.body).appendChild(theDiv);
+
+      const shadowChild = document.createElement('div');
+      root.appendChild(shadowChild);
+
+      const spy = sinon.spy();
+
+      // Add event listener to the shadow root
+      ShadyDOM.wrap(ShadyDOM.wrap(theDiv).shadowRoot).addEventListener('anEvent', spy);
+
+      // Dispatch a bubbling event to the a shadowRoot child
+      ShadyDOM.wrap(shadowChild).dispatchEvent(new CustomEvent('anEvent', {bubbles: true}));
+
+      assert.isTrue(spy.called, 'Callback should be called on shadowRoot');
+    });
+
     test('scoped composed does not reach shadowRoot', function() {
       // Create a div element with a shadow root
       const theDiv = document.createElement('div');
@@ -349,7 +369,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Add event listener to the shadow root
       ShadyDOM.wrap(ShadyDOM.wrap(theDiv).shadowRoot).addEventListener('composed', spy);
 
-      // Dispatch a comosed event to the div element (not its shadow root)
+      // Dispatch a composed event to the div element (not its shadow root)
       ShadyDOM.wrap(theDiv).dispatchEvent(new CustomEvent('composed', {bubbles: true, composed: true}));
 
       assert.isFalse(spy.called, 'Callback should not be called on shadowRoot');
@@ -368,10 +388,76 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // Add event listener to the shadow root
       ShadyDOM.wrap(ShadyDOM.wrap(theDiv).shadowRoot).addEventListener('composed', spy);
 
-      // Dispatch a comosed event to a child of the div element (not its shadow root)
+      // Dispatch a composed event to a child of the div element (not its shadow root)
       ShadyDOM.wrap(child).dispatchEvent(new CustomEvent('composed', {bubbles: true, composed: true}));
 
       assert.isFalse(spy.called, 'Callback should not be called on shadowRoot');
+    });
+
+    test('bubbling events reach <slot>', function() {
+      // Create a div element with a shadow root
+      const theDiv = document.createElement('div');
+      const root = ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrap(document.body).appendChild(theDiv);
+
+      const slot = document.createElement('slot');
+      root.appendChild(slot);
+      const child = document.createElement('div');
+      ShadyDOM.wrap(theDiv).appendChild(child);
+
+      const spy = sinon.spy();
+
+      // Add event listener to the <slot>
+      ShadyDOM.wrap(slot).addEventListener('bubbling', spy);
+
+      // Dispatch a bubbling event to the child distributed to the slot
+      ShadyDOM.wrap(child).dispatchEvent(new CustomEvent('bubbling', {bubbles: true}));
+
+      assert.isTrue(spy.called, 'Callback should be called on <slot>');
+    });
+
+    test('events on slot parent do not reach <slot>', function() {
+      // Create a div element with a shadow root
+      const theDiv = document.createElement('div');
+      const root = ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrap(document.body).appendChild(theDiv);
+
+      const slot = document.createElement('slot');
+      const slotParent = document.createElement('div');
+      slotParent.appendChild(slot);
+      root.appendChild(slotParent);
+
+      const spy = sinon.spy();
+
+      // Add event listener to the shadow root
+      ShadyDOM.wrap(slot).addEventListener('bubbling', spy);
+
+      // Dispatch a bubbling event to the slot parent
+      slotParent.dispatchEvent(new CustomEvent('bubbling', {bubbles: true}));
+
+      assert.isFalse(spy.called, 'Callback should not be called on <slot>');
+    });
+
+    test('events bubbling to slot parent do not reach <slot>', function() {
+      // Create a div element with a shadow root
+      const theDiv = document.createElement('div');
+      const root = ShadyDOM.wrap(theDiv).attachShadow({mode: 'open'});
+      ShadyDOM.wrap(document.body).appendChild(theDiv);
+
+      const slot = document.createElement('slot');
+      root.appendChild(slot);
+      const child = document.createElement('div');
+      root.appendChild(child);
+
+      const spy = sinon.spy();
+
+      // Add event listener to the <slot>
+      ShadyDOM.wrap(slot).addEventListener('bubbling', spy);
+
+      // Dispatch a bubbling event to a sibling of the slot (not distributed to it)
+      ShadyDOM.wrap(child).dispatchEvent(new CustomEvent('bubbling', {bubbles: true}));
+
+      assert.isFalse(spy.called, 'Callback should not be called on <slot>');
     });
 
     test('document events retarget', function() {
@@ -744,8 +830,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         track(mid);
         track(ShadyDOM.wrap(mid).shadowRoot);
         let slot = document.createElement('slot');
-        track(slot);
         ShadyDOM.wrap(ShadyDOM.wrap(mid).shadowRoot).appendChild(slot);
+        track(slot);
         ShadyDOM.wrap(ShadyDOM.wrap(top).shadowRoot).appendChild(mid);
 
         let bot = document.createElement('div');

--- a/tests/event-path.html
+++ b/tests/event-path.html
@@ -549,6 +549,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.isNull(scoped, 'scoped events should fire on shadowRoot after listener removed');
     });
 
+    test('addEventListener using event options to set capture false', function() {
+      const parent = document.createElement('div');
+      document.body.appendChild(parent);
+      const child = document.createElement('div');
+      ShadyDOM.wrap(parent).appendChild(child);
+      let heardEvent = false;
+      function listener(e) {
+        assert.equal(e.eventPhase, Event.BUBBLING_PHASE);
+        heardEvent = true;
+      }
+      ShadyDOM.wrap(parent).addEventListener('foo', listener);
+      ShadyDOM.wrap(child).dispatchEvent(new Event('foo', {bubbles: true}));
+      ShadyDOM.flush();
+      assert.isTrue(heardEvent);
+      document.body.removeChild(parent);
+    });
+
     test('should use bubbling phase for event listeners added via properties', function () {
       if (!hasOnListenersOnPrototype) {
         this.skip();


### PR DESCRIPTION
Fixes #252. Previously only 'slotchange' listener was supported but we now support all listeners. This is done by installing the event listener on the <slot> parent and only running the listener if the <slot> is in the event's `composedPath`.