### PR TITLE
Fixes incompatibility between SD and CE when instance patching is needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1085,9 +1085,9 @@
       }
     },
     "@webcomponents/custom-elements": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.2.1.tgz",
-      "integrity": "sha512-flmTp4rVbBkcUIF3eBO3LNoAaYvleTdhPZKzdzr6iztWLLrxCctcK+7MAQeC3/SPjc3JDdC3jYLMRF4R6C3f9g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.2.3.tgz",
+      "integrity": "sha512-qRLglUZpJFzXrPkVxWbxz8mv2Yy85jOHaPIHcZKHg3bNty3DOBVd0tbXpmm1372uHeycB+IMEWqMRo01HwMXIw==",
       "dev": true
     },
     "@webcomponents/shadycss": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "homepage": "https://webcomponents.org/polyfills",
   "devDependencies": {
-    "@webcomponents/custom-elements": "^1.1.3",
+    "@webcomponents/custom-elements": "^1.2.3",
     "@webcomponents/shadycss": "^1.7.1",
     "@webcomponents/template": "^1.3.1",
     "@webcomponents/webcomponents-platform": "^1.0.0",

--- a/src/patch-instances.js
+++ b/src/patch-instances.js
@@ -159,13 +159,13 @@ export let patchInsideElementAccessors = noInstancePatching ?
       // * When SD is in patching mode, SD calls through to native
       // methods not patched by CE (since SD is at the bottom) and CE does not
       // upgrade, connect, or disconnect elements. Therefore do *not patch*
-      // these acceessoes in this case.
+      // these accessors in this case.
       // * When SD is in `noPatch` mode, the SD patches call through to
       // "native" methods that are patched by CE (since CE is at the bottom).
       // Therefore continue to patch in this case.
       // If customElements is not loaded, then these accessors should be
       // patched so they work correctly.
-      if (!window.customElements || utils.settings.noPatch) {
+      if (!window['customElements'] || utils.settings.noPatch) {
         utils.patchProperties(element, TextContentInnerHTMLDescriptors);
       }
     }

--- a/src/patch-shadyRoot.js
+++ b/src/patch-shadyRoot.js
@@ -10,7 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 import * as utils from './utils.js';
 import {NodePatches} from './patches/Node.js';
-import {OutsideDescriptors, InsideDescriptors} from './patch-instances.js';
+import {OutsideDescriptors, InsideDescriptors, TextContentInnerHTMLDescriptors} from './patch-instances.js';
 import {ParentNodePatches} from './patches/ParentNode.js';
 import {DocumentOrFragmentPatches} from './patches/DocumentOrFragment.js';
 import {DocumentOrShadowRootPatches} from './patches/DocumentOrShadowRoot.js';
@@ -45,6 +45,7 @@ const patchShadyAccessors = (proto, prefix) => {
   } else if (!utils.settings.hasDescriptors) {
     utils.patchProperties(proto, OutsideDescriptors);
     utils.patchProperties(proto, InsideDescriptors);
+    utils.patchProperties(proto, TextContentInnerHTMLDescriptors);
   }
 }
 

--- a/tests/shady-dynamic.html
+++ b/tests/shady-dynamic.html
@@ -1400,6 +1400,15 @@ suite('Accessors', function() {
     assert.equal(ShadyDOM.wrap(element.content).childNodes.length, 2);
   });
 
+  test('innerHTML removing a custom element', function() {
+    var testElement = document.createElement('div');
+    ShadyDOM.wrap(document.body).appendChild(testElement);
+    const simple = document.createElement('x-simple');
+    testElement.appendChild(simple);
+    ShadyDOM.wrap(testElement).innerHTML = '';
+    assert.isTrue(simple._isDisconnected);
+  });
+
   test('innerHTML containing custom element', function() {
     var testElement = document.createElement('div');
     ShadyDOM.wrap(document.body).appendChild(testElement);
@@ -1414,6 +1423,36 @@ suite('Accessors', function() {
     const el = ShadyDOM.wrap(testElement).firstChild;
     ShadyDOM.wrap(testElement).textContent = '';
     assert.isTrue(el._isDisconnected);
+  });
+
+  suite('innerHTML and textContent when using ShadyDOM.patch', function() {
+    test('innerHTML removing a custom element', function() {
+      var testElement = document.createElement('div');
+      ShadyDOM.patch(testElement);
+      ShadyDOM.wrap(document.body).appendChild(testElement);
+      const simple = document.createElement('x-simple');
+      testElement.appendChild(simple);
+      ShadyDOM.wrap(testElement).innerHTML = '';
+      assert.isTrue(simple._isDisconnected);
+    });
+
+    test('innerHTML containing custom element', function() {
+      var testElement = document.createElement('div');
+      ShadyDOM.patch(testElement);
+      ShadyDOM.wrap(document.body).appendChild(testElement);
+      ShadyDOM.wrap(testElement).innerHTML = '<x-simple></x-simple>';
+      assert.isTrue(ShadyDOM.wrap(testElement).firstChild._initialized);
+    });
+
+    test('textContent that removes custom element', function() {
+      var testElement = document.createElement('div');
+      ShadyDOM.patch(testElement);
+      ShadyDOM.wrap(document.body).appendChild(testElement);
+      ShadyDOM.wrap(testElement).innerHTML = '<x-simple></x-simple>';
+      const el = ShadyDOM.wrap(testElement).firstChild;
+      ShadyDOM.wrap(testElement).textContent = '';
+      assert.isTrue(el._isDisconnected);
+    });
   });
 
 });


### PR DESCRIPTION
Fixes #303.

When ShadyDOM.patch is used in conjunction with the customElements polyfill, the patches for textContent and innerHTML did not work correctly.

The issue is addressed by not applying SD instance patching for these accessors except when in noPatch mode.