### PR TITLE
 Ensure patched querySelectorAll returns an HTMLCollection

### DIFF
--- a/src/patches/ParentNode.js
+++ b/src/patches/ParentNode.js
@@ -125,11 +125,11 @@ export const QueryPatches = utils.getOwnPropertyDescriptors({
     if (useNative) {
       const o = Array.prototype.slice.call(this[utils.NATIVE_PREFIX + 'querySelectorAll'](selector));
       const root = this[utils.SHADY_PREFIX + 'getRootNode']();
-      return o.filter(e => e[utils.SHADY_PREFIX + 'getRootNode']() == root);
+      return utils.createPolyfilledHTMLCollection(o.filter(e => e[utils.SHADY_PREFIX + 'getRootNode']() == root));
     }
-    return query(this, function(n) {
+    return utils.createPolyfilledHTMLCollection(query(this, function(n) {
       return utils.matchesSelector(n, selector);
-    });
+    }));
   }
 
 });

--- a/tests/shady.html
+++ b/tests/shady.html
@@ -461,8 +461,8 @@ suite('Mutate light DOM', function() {
     ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
     var childLocalSub = ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).lastChild;
     ShadyDOM.flush();
-    assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelectorAll('span#main')), [hostLocalMain]);
-    assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelectorAll('div#sub')), [childLightSub]);
+    assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelectorAll('span#main').item(0), hostLocalMain);
+    assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelectorAll('div#sub')[0], childLightSub);
     assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).querySelectorAll('span#sub')), [childLocalSub]);
   });
 
@@ -477,9 +477,9 @@ suite('Mutate light DOM', function() {
     var childLightSub = ShadyDOM.wrap(child).lastElementChild;
     ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
     ShadyDOM.flush();
-    assert.deepEqual(Array.from(ShadyDOM.wrap(host).querySelectorAll('div#main')), [hostLightMain]);
+    assert.deepEqual(ShadyDOM.wrap(host).querySelectorAll('div#main').item(0), hostLightMain);
     assert.deepEqual(Array.from(ShadyDOM.wrap(host).querySelectorAll('#sub')), []);
-    assert.deepEqual(Array.from(ShadyDOM.wrap(child).querySelectorAll('div#sub')), [childLightSub]);
+    assert.deepEqual(ShadyDOM.wrap(child).querySelectorAll('div#sub')[0], childLightSub);
   });
 
   test('querySelectorAll useNative (light dom)', function() {
@@ -493,9 +493,9 @@ suite('Mutate light DOM', function() {
     var childLightSub = ShadyDOM.wrap(child).lastElementChild;
     ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
     ShadyDOM.flush();
-    assert.deepEqual(Array.from(ShadyDOM.wrap(host).querySelectorAll('div#main', true)), [hostLightMain]);
+    assert.deepEqual(ShadyDOM.wrap(host).querySelectorAll('div#main', true).item(0), hostLightMain);
     assert.deepEqual(Array.from(ShadyDOM.wrap(host).querySelectorAll('#sub', true)), []);
-    assert.deepEqual(Array.from(ShadyDOM.wrap(child).querySelectorAll('div#sub', true)), [childLightSub]);
+    assert.deepEqual(ShadyDOM.wrap(child).querySelectorAll('div#sub', true)[0], childLightSub);
   });
 
 });

--- a/tests/shady.html
+++ b/tests/shady.html
@@ -461,9 +461,9 @@ suite('Mutate light DOM', function() {
     ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
     var childLocalSub = ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).lastChild;
     ShadyDOM.flush();
-    assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelectorAll('span#main'), [hostLocalMain]);
-    assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelectorAll('div#sub'), [childLightSub]);
-    assert.deepEqual(ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).querySelectorAll('span#sub'), [childLocalSub]);
+    assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelectorAll('span#main')), [hostLocalMain]);
+    assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(host).shadowRoot).querySelectorAll('div#sub')), [childLightSub]);
+    assert.deepEqual(Array.from(ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).querySelectorAll('span#sub')), [childLocalSub]);
   });
 
   test('querySelectorAll (light dom)', function() {
@@ -477,9 +477,9 @@ suite('Mutate light DOM', function() {
     var childLightSub = ShadyDOM.wrap(child).lastElementChild;
     ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
     ShadyDOM.flush();
-    assert.deepEqual(ShadyDOM.wrap(host).querySelectorAll('div#main'), [hostLightMain]);
-    assert.deepEqual(ShadyDOM.wrap(host).querySelectorAll('#sub'), []);
-    assert.deepEqual(ShadyDOM.wrap(child).querySelectorAll('div#sub'), [childLightSub]);
+    assert.deepEqual(Array.from(ShadyDOM.wrap(host).querySelectorAll('div#main')), [hostLightMain]);
+    assert.deepEqual(Array.from(ShadyDOM.wrap(host).querySelectorAll('#sub')), []);
+    assert.deepEqual(Array.from(ShadyDOM.wrap(child).querySelectorAll('div#sub')), [childLightSub]);
   });
 
   test('querySelectorAll useNative (light dom)', function() {
@@ -493,9 +493,9 @@ suite('Mutate light DOM', function() {
     var childLightSub = ShadyDOM.wrap(child).lastElementChild;
     ShadyDOM.wrap(ShadyDOM.wrap(child).shadowRoot).innerHTML = '<slot></slot><span id="sub"></span>';
     ShadyDOM.flush();
-    assert.deepEqual(ShadyDOM.wrap(host).querySelectorAll('div#main', true), [hostLightMain]);
-    assert.deepEqual(ShadyDOM.wrap(host).querySelectorAll('#sub', true), []);
-    assert.deepEqual(ShadyDOM.wrap(child).querySelectorAll('div#sub', true), [childLightSub]);
+    assert.deepEqual(Array.from(ShadyDOM.wrap(host).querySelectorAll('div#main', true)), [hostLightMain]);
+    assert.deepEqual(Array.from(ShadyDOM.wrap(host).querySelectorAll('#sub', true)), []);
+    assert.deepEqual(Array.from(ShadyDOM.wrap(child).querySelectorAll('div#sub', true)), [childLightSub]);
   });
 
 });


### PR DESCRIPTION
Fixes #254 

The patched `querySelectorAll` function currently returns an `Array` type. This PR uses the `utils.createPolyfilledHTMLCollection` utility to convert from an `Array` to a "NodeList-Like" (`HTMLCollection`) object for better API compatibility with the spec.

The resulting `HTMLCollection` will support accessing via index (property) or `.item(index)` as you can with the native qSA implementation. Usage of `Array.from` on the resulting polyfilled `HTMLCollection` still works as expected as well.

I've updated the related tests in `shady.html` to use both syntaxes, as well as `Array.from`. Please let me know if you have any preference on those tests, and I can update the PR.