### PR TITLE
Avoid errors when `Object.getOwnPropertyNames` is weirdly patched

### DIFF
--- a/src/patch-instances.js
+++ b/src/patch-instances.js
@@ -125,7 +125,7 @@ const makeNonEnumerable = (descriptors) => {
   for (let prop in descriptors) {
     const descriptor = descriptors[prop];
     // NOTE, the only known reason the descriptor wouldn't exist here is
-    // if someone has patched `getOwnPropertyNames`, but we've seen this
+    // if someone has patched `Object.getOwnPropertyNames`, but we've seen this
     // so this is just to be extra safe.
     if (descriptor) {
       descriptor.enumerable = false;

--- a/src/patch-instances.js
+++ b/src/patch-instances.js
@@ -121,17 +121,21 @@ export const OutsideDescriptors = utils.getOwnPropertyDescriptors({
 
 });
 
-for (let prop in InsideDescriptors) {
-  InsideDescriptors[prop].enumerable = false;
+const makeNonEnumerable = (descriptors) => {
+  for (let prop in descriptors) {
+    const descriptor = descriptors[prop];
+    // NOTE, the only known reason the descriptor wouldn't exist here is
+    // if someone has patched `getOwnPropertyNames`, but we've seen this
+    // so this is just to be extra safe.
+    if (descriptor) {
+      descriptor.enumerable = false;
+    }
+  }
 }
 
-for (let prop in TextContentInnerHTMLDescriptors) {
-  TextContentInnerHTMLDescriptors[prop].enumerable = false;
-}
-
-for (let prop in OutsideDescriptors) {
-  OutsideDescriptors[prop].enumerable = false;
-}
+makeNonEnumerable(InsideDescriptors);
+makeNonEnumerable(TextContentInnerHTMLDescriptors);
+makeNonEnumerable(OutsideDescriptors);
 
 const noInstancePatching = utils.settings.hasDescriptors || utils.settings.noPatch;
 


### PR DESCRIPTION
When making descriptors non-enumerable, adds a check that the descriptor exists. This is in case someone has patched `Object.getOwnPropertyNames` to return a weird set of properties.