### PR TITLE
Patch `dispatchEvent` on Window

### DIFF
--- a/src/patch-events.js
+++ b/src/patch-events.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import * as utils from './utils.js';
+import {flush} from './flush.js';
 import {shadyDataForNode} from './shady-data.js';
 
 /*
@@ -384,6 +385,12 @@ function getEventWrappers(eventLike) {
 
 function targetNeedsPathCheck(node) {
   return utils.isShadyRoot(node) || node.localName === 'slot';
+}
+
+/** @this {Node} */
+export function dispatchEvent(event) {
+  flush();
+  return this[utils.NATIVE_PREFIX + 'dispatchEvent'](event);
 }
 
 /**

--- a/src/patches/EventTarget.js
+++ b/src/patches/EventTarget.js
@@ -9,16 +9,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import * as utils from '../utils.js';
-import {flush} from '../flush.js';
-import {addEventListener, removeEventListener} from '../patch-events.js';
+import {addEventListener, removeEventListener, dispatchEvent} from '../patch-events.js';
 
 export const EventTargetPatches = utils.getOwnPropertyDescriptors({
 
-  /** @this {Node} */
-  dispatchEvent(event) {
-    flush();
-    return this[utils.NATIVE_PREFIX + 'dispatchEvent'](event);
-  },
+  dispatchEvent,
 
   addEventListener,
 

--- a/src/patches/Window.js
+++ b/src/patches/Window.js
@@ -8,9 +8,13 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 import * as utils from '../utils.js';
-import {addEventListener, removeEventListener} from '../patch-events.js';
+import {addEventListener, removeEventListener, dispatchEvent} from '../patch-events.js';
 
 export const WindowPatches = utils.getOwnPropertyDescriptors({
+
+  // Ensure that `dispatchEvent` is patched directly on Window since on
+  // IE11, Window does not descend from EventTarget.
+  dispatchEvent,
 
   // NOTE: ensure these methods are bound to `window` so that `this` is correct
   // when called directly from global context without a receiver; e.g.

--- a/tests/event-path.html
+++ b/tests/event-path.html
@@ -923,6 +923,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       ShadyDOM.wrap(document.body).appendChild(div);
       ShadyDOM.wrap(div).dispatchEvent(new MouseEvent('mouseover', {bubbles: true, cancelable: true, relatedTarget: document}));
     });
+
+    test('events on window', function() {
+      const w = ShadyDOM.wrap(window);
+      let heardEvent = false;
+      w.addEventListener('foo', (e) => {
+        heardEvent = true;
+      })
+      w.dispatchEvent(new Event('foo'));
+      assert.isTrue(heardEvent);
+    });
   });
   </script>
 </body>


### PR DESCRIPTION
Fixes #335. This is necessary because on IE11, Window does not descend from EventTarget where dispatchEvent is otherwise patched.

When in `noPatch` mode, the `ShadyDOM.wrap` method returns an object which calls methods patched at a special location. If `Window.dispatchEvent` is not specifically patched, the wrapper fails when calling `ShadyDOM.wrap(window).dispatchEvent` on IE11.