### PR TITLE
Fix edge case with `removeAttribute('class')`

### DIFF
--- a/src/patches/Element.js
+++ b/src/patches/Element.js
@@ -123,6 +123,9 @@ export const ElementPatches = utils.getOwnPropertyDescriptors({
     } else if (!scopeClassAttribute(this, attr, '')) {
       this[utils.NATIVE_PREFIX + 'removeAttribute'](attr);
       distributeAttributeChange(this, attr);
+    } else if (this.getAttribute(attr) === '') {
+      // ensure that "class" attribute is fully removed if ShadyCSS does not keep scoping
+      this[utils.NATIVE_PREFIX + 'removeAttribute'](attr);
     }
   },
 

--- a/tests/sync-style-scoping.html
+++ b/tests/sync-style-scoping.html
@@ -294,6 +294,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(csfn(span), 'naive-element');
         });
 
+        test('`removeAttribute(\'class\', ...)` removes if class is empty', function () {
+          const el = document.createElement('naive-element');
+          const span = document.createElement('span');
+          ShadyDOM.wrap(ShadyDOM.wrap(el)).appendChild(span);
+          ShadyDOM.wrap(span).removeAttribute('class');
+          assert.equal(span.getAttribute('class'), null);
+        });
+
         test('`className` scopes correctly', function() {
           const el = document.createElement('naive-element');
           const span = document.createElement('span');


### PR DESCRIPTION
Make sure `removeAttribute('class')` actually removes attribute if
ShadyCSS does not need to keep scoping.

<!-- Instructions: https://github.com/webcomponents/shadydom/blob/master/CONTRIBUTING.md -->
### Reference Issue
<!-- Example: Fixes #1234 -->
