### PR TITLE
Add externs for Polymer template instance properties

### DIFF
--- a/externs/shadydom.js
+++ b/externs/shadydom.js
@@ -52,3 +52,5 @@ DocumentFragment.prototype.$;
 DocumentFragment.prototype.__noInsertionPoint;
 /** @type {!Array<!Node>} */
 DocumentFragment.prototype.nodeList;
+/** type {!Object} */
+DocumentFragment.prototype.templateInfo;

--- a/externs/shadydom.js
+++ b/externs/shadydom.js
@@ -43,3 +43,12 @@ Event.prototype.__relatedTargetComposedPath;
  * Prevent renaming of this method on ShadyRoot for testing and debugging.
  */
 ShadowRoot.prototype._renderSelf = function(){};
+
+// Prevent renaming of properties used by Polymer templates with
+// shadyUpgradeFragment optimization
+/** @type {!Object} */
+DocumentFragment.prototype.$;
+/** @type {boolean} */
+DocumentFragment.prototype.__noInsertionPoint;
+/** @type {!Array<!Node>} */
+DocumentFragment.prototype.nodeList;

--- a/externs/shadydom.js
+++ b/externs/shadydom.js
@@ -52,5 +52,5 @@ DocumentFragment.prototype.$;
 DocumentFragment.prototype.__noInsertionPoint;
 /** @type {!Array<!Node>} */
 DocumentFragment.prototype.nodeList;
-/** type {!Object} */
+/** @type {!Object} */
 DocumentFragment.prototype.templateInfo;


### PR DESCRIPTION
This symbols can collide when using the `shadyUpgradeFragment` optimization.

Fixes #344 
